### PR TITLE
util/time out of the core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ set(SRCS
     src/c/core/serialization/xrce_protocol.c
     src/c/core/serialization/xrce_header.c
     src/c/core/serialization/xrce_subheader.c
-    src/c/core/util/time.c
+    src/c/util/time.c
     $<$<OR:$<BOOL:${VERBOSE_MESSAGE}>,$<BOOL:${VERBOSE_SERIALIZATION}>>:src/c/core/log/log.c>
     $<$<BOOL:${PROFILE_COMMON_CREATE_ENTITIES}>:src/c/profile/session/common_create_entities.c>
     $<$<BOOL:${PROFILE_CREATE_ENTITIES_REF}>:src/c/profile/session/create_entities_ref.c>

--- a/include/uxr/client/util/time.h
+++ b/include/uxr/client/util/time.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _UXR_CLIENT_CORE_UTIL_TIME_H_
-#define _UXR_CLIENT_CORE_UTIL_TIME_H_
+#ifndef _UXR_CLIENT_UTIL_TIME_H_
+#define _UXR_CLIENT_UTIL_TIME_H_
 
 #ifdef __cplusplus
 extern "C"
@@ -29,4 +29,4 @@ UXRDLLAPI int64_t uxr_millis(void);
 }
 #endif
 
-#endif // _UXR_CLIENT_CORE_UTIL_TIME_H_
+#endif // _UXR_CLIENT_UTIL_TIME_H_

--- a/src/c/core/log/log.c
+++ b/src/c/core/log/log.c
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <uxr/client/core/session/session_info.h>
-#include <uxr/client/core/util/time.h>
+#include <uxr/client/util/time.h>
 
 #include "../serialization/xrce_header_internal.h"
 #include "../serialization/xrce_protocol_internal.h"

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -1,5 +1,5 @@
 #include <uxr/client/core/session/session.h>
-#include <uxr/client/core/util/time.h>
+#include <uxr/client/util/time.h>
 #include <uxr/client/core/communication/communication.h>
 #include <uxr/client/config.h>
 

--- a/src/c/profile/transport/serial_transport_linux.c
+++ b/src/c/profile/transport/serial_transport_linux.c
@@ -1,5 +1,5 @@
 #include <uxr/client/profile/transport/serial_transport_linux.h>
-#include <uxr/client/core/util/time.h>
+#include <uxr/client/util/time.h>
 
 #include "../../core/communication/serial_protocol_internal.h"
 

--- a/src/c/profile/transport/tcp_transport_linux.c
+++ b/src/c/profile/transport/tcp_transport_linux.c
@@ -1,5 +1,5 @@
 #include <uxr/client/profile/transport/tcp_transport_linux.h>
-#include <uxr/client/core/util/time.h>
+#include <uxr/client/util/time.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <netinet/in.h>

--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -1,4 +1,4 @@
-#include <uxr/client/core/util/time.h>
+#include <uxr/client/util/time.h>
 #include <time.h>
 
 #ifdef WIN32


### PR DESCRIPTION
The util package (that contains the time file) has been moved out from the core package for two reasons:
1. The utilities can be used by the core package, but also by the profiles and by the user directly.
2. The utils can be platform dependent (as time). This break the core purposes by two reasons:
    1. The core must not contains platform dependent code.
    2. The user can not touch any of core package. Only can create its own profiles or edite some of them (like a transport for a new platform).