### PR TITLE
api change: configure -> create at some functions.

### DIFF
--- a/examples/Deployment/configurator_client.c
+++ b/examples/Deployment/configurator_client.c
@@ -134,15 +134,15 @@ void create_publisher(uxrSession* session, uint16_t id)
 
     uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
     const char* topic_xml = "<dds><topic><name>HelloWorldTopic</name><dataType>HelloWorld</dataType></topic></dds>";
-    uint16_t topic_req = uxr_buffer_configure_topic_xml(session, output, topic_id, participant_id, topic_xml, 0);
+    uint16_t topic_req = uxr_buffer_create_topic_xml(session, output, topic_id, participant_id, topic_xml, 0);
 
     uxrObjectId publisher_id = uxr_object_id(id, UXR_PUBLISHER_ID);
     const char* publisher_xml = "<publisher name=\"MyPublisher\">";
-    uint16_t publisher_req = uxr_buffer_configure_publisher_xml(session, output, publisher_id, participant_id, publisher_xml, 0);
+    uint16_t publisher_req = uxr_buffer_create_publisher_xml(session, output, publisher_id, participant_id, publisher_xml, 0);
 
     uxrObjectId datawriter_id = uxr_object_id(id, UXR_DATAWRITER_ID);
     const char* datawriter_xml = "<profiles><publisher profile_name=\"default_xrce_publisher_profile\"><topic><kind>NO_KEY</kind><name>HelloWorldTopic</name><dataType>HelloWorld</dataType><historyQos><kind>KEEP_LAST</kind><depth>5</depth></historyQos><durability><kind>TRANSIENT_LOCAL</kind></durability></topic></publisher></profiles>";
-    uint16_t datawriter_req = uxr_buffer_configure_datawriter_xml(session, output, datawriter_id, publisher_id, datawriter_xml, 0);
+    uint16_t datawriter_req = uxr_buffer_create_datawriter_xml(session, output, datawriter_id, publisher_id, datawriter_xml, 0);
 
     uint16_t requests[4] = {participant_req, topic_req, publisher_req, datawriter_req};
     wait_status(session, requests);
@@ -158,15 +158,15 @@ void create_subscriber(uxrSession* session, uint16_t id)
 
     uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
     const char* topic_xml = "<dds><topic><name>HelloWorldTopic</name><dataType>HelloWorld</dataType></topic></dds>";
-    uint16_t topic_req = uxr_buffer_configure_topic_xml(session, output, topic_id, participant_id, topic_xml, 0);
+    uint16_t topic_req = uxr_buffer_create_topic_xml(session, output, topic_id, participant_id, topic_xml, 0);
 
     uxrObjectId subscriber_id = uxr_object_id(id, UXR_SUBSCRIBER_ID);
     const char* subscriber_xml = "<subscriber name=\"MySubscriber\">";
-    uint16_t subscriber_req = uxr_buffer_configure_subscriber_xml(session, output, subscriber_id, participant_id, subscriber_xml, 0);
+    uint16_t subscriber_req = uxr_buffer_create_subscriber_xml(session, output, subscriber_id, participant_id, subscriber_xml, 0);
 
     uxrObjectId datareader_id = uxr_object_id(id, UXR_DATAREADER_ID);
     const char* datareader_xml = "<profiles><subscriber profile_name=\"default_xrce_subscriber_profile\"><topic><kind>NO_KEY</kind><name>HelloWorldTopic</name><dataType>HelloWorld</dataType><historyQos><kind>KEEP_LAST</kind><depth>5</depth></historyQos><durability><kind>TRANSIENT_LOCAL</kind></durability></topic></subscriber></profiles>";
-    uint16_t datareader_req = uxr_buffer_configure_datareader_xml(session, output, datareader_id, subscriber_id, datareader_xml, 0);
+    uint16_t datareader_req = uxr_buffer_create_datareader_xml(session, output, datareader_id, subscriber_id, datareader_xml, 0);
 
     uint16_t requests[4] = {participant_req, topic_req, subscriber_req, datareader_req};
     wait_status(session, requests);

--- a/examples/PublishHelloWorld/main.c
+++ b/examples/PublishHelloWorld/main.c
@@ -67,7 +67,7 @@ int main(int args, char** argv)
                                           "</rtps>"
                                       "</participant>"
                                   "</dds>";
-    uint16_t participant_req = uxr_buffer_configure_participant_xml(&session, reliable_out, participant_id, 0, participant_xml, UXR_REPLACE);
+    uint16_t participant_req = uxr_buffer_create_participant_xml(&session, reliable_out, participant_id, 0, participant_xml, UXR_REPLACE);
 
     uxrObjectId topic_id = uxr_object_id(0x01, UXR_TOPIC_ID);
     const char* topic_xml = "<dds>"
@@ -76,11 +76,11 @@ int main(int args, char** argv)
                                     "<dataType>HelloWorld</dataType>"
                                 "</topic>"
                             "</dds>";
-    uint16_t topic_req = uxr_buffer_configure_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
+    uint16_t topic_req = uxr_buffer_create_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
 
     uxrObjectId publisher_id = uxr_object_id(0x01, UXR_PUBLISHER_ID);
     const char* publisher_xml = "";
-    uint16_t publisher_req = uxr_buffer_configure_publisher_xml(&session, reliable_out, publisher_id, participant_id, publisher_xml, UXR_REPLACE);
+    uint16_t publisher_req = uxr_buffer_create_publisher_xml(&session, reliable_out, publisher_id, participant_id, publisher_xml, UXR_REPLACE);
 
     uxrObjectId datawriter_id = uxr_object_id(0x01, UXR_DATAWRITER_ID);
     const char* datawriter_xml = "<dds>"
@@ -92,7 +92,7 @@ int main(int args, char** argv)
                                          "</topic>"
                                      "</data_writer>"
                                  "</dds>";
-    uint16_t datawriter_req = uxr_buffer_configure_datawriter_xml(&session, reliable_out, datawriter_id, publisher_id, datawriter_xml, UXR_REPLACE);
+    uint16_t datawriter_req = uxr_buffer_create_datawriter_xml(&session, reliable_out, datawriter_id, publisher_id, datawriter_xml, UXR_REPLACE);
 
     // Send create entities message and wait its status
     uint8_t status[4];

--- a/examples/ShapesDemo/main.c
+++ b/examples/ShapesDemo/main.c
@@ -253,14 +253,14 @@ bool compute_command(uxrSession* session, uxrStreamId* stream_id, int length, co
         uxrObjectId publisher_id = uxr_object_id((uint16_t)arg1, UXR_PUBLISHER_ID);
         uxrObjectId participant_id = uxr_object_id((uint16_t)arg2, UXR_PARTICIPANT_ID);
         const char* publisher_xml = "";
-        (void) uxr_buffer_configure_publisher_xml(session, *stream_id, publisher_id, participant_id, publisher_xml, 0);
+        (void) uxr_buffer_create_publisher_xml(session, *stream_id, publisher_id, participant_id, publisher_xml, 0);
     }
     else if(0 == strcmp(name, "create_subscriber") && 3 == length)
     {
         uxrObjectId subscriber_id = uxr_object_id((uint16_t)arg1, UXR_SUBSCRIBER_ID);
         uxrObjectId participant_id = uxr_object_id((uint16_t)arg2, UXR_PARTICIPANT_ID);
         const char* subscriber_xml = "";
-        (void) uxr_buffer_configure_subscriber_xml(session, *stream_id, subscriber_id, participant_id, subscriber_xml, 0);
+        (void) uxr_buffer_create_subscriber_xml(session, *stream_id, subscriber_id, participant_id, subscriber_xml, 0);
     }
     else if(0 == strcmp(name, "create_datawriter") && 3 == length)
     {

--- a/examples/SubscribeHelloWorld/main.c
+++ b/examples/SubscribeHelloWorld/main.c
@@ -80,7 +80,7 @@ int main(int args, char** argv)
                                           "</rtps>"
                                       "</participant>"
                                   "</dds>";
-    uint16_t participant_req = uxr_buffer_configure_participant_xml(&session, reliable_out, participant_id, 0, participant_xml, UXR_REPLACE);
+    uint16_t participant_req = uxr_buffer_create_participant_xml(&session, reliable_out, participant_id, 0, participant_xml, UXR_REPLACE);
 
     uxrObjectId topic_id = uxr_object_id(0x01, UXR_TOPIC_ID);
     const char* topic_xml = "<dds>"
@@ -89,11 +89,11 @@ int main(int args, char** argv)
                                     "<dataType>HelloWorld</dataType>"
                                 "</topic>"
                             "</dds>";
-    uint16_t topic_req = uxr_buffer_configure_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
+    uint16_t topic_req = uxr_buffer_create_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
 
     uxrObjectId subscriber_id = uxr_object_id(0x01, UXR_SUBSCRIBER_ID);
     const char* subscriber_xml = "";
-    uint16_t subscriber_req = uxr_buffer_configure_subscriber_xml(&session, reliable_out, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
+    uint16_t subscriber_req = uxr_buffer_create_subscriber_xml(&session, reliable_out, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
 
     uxrObjectId datareader_id = uxr_object_id(0x01, UXR_DATAREADER_ID);
     const char* datareader_xml = "<dds>"
@@ -105,7 +105,7 @@ int main(int args, char** argv)
                                          "</topic>"
                                      "</data_reader>"
                                  "</dds>";
-    uint16_t datareader_req = uxr_buffer_configure_datareader_xml(&session, reliable_out, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
+    uint16_t datareader_req = uxr_buffer_create_datareader_xml(&session, reliable_out, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
 
     // Send create entities message and wait its status
     uint8_t status[4];

--- a/include/uxr/client/profile/session/create_entities_xml.h
+++ b/include/uxr/client/profile/session/create_entities_xml.h
@@ -22,22 +22,22 @@ extern "C"
 
 #include <uxr/client/profile/session/common_create_entities.h>
 
-UXRDLLAPI uint16_t uxr_buffer_configure_participant_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_participant_xml(uxrSession* session, uxrStreamId stream_id,
                                          uxrObjectId object_id, uint16_t domain, const char* xml, uint8_t mode);
 
-UXRDLLAPI uint16_t uxr_buffer_configure_topic_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_topic_xml(uxrSession* session, uxrStreamId stream_id,
                                    uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode);
 
-UXRDLLAPI uint16_t uxr_buffer_configure_publisher_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_publisher_xml(uxrSession* session, uxrStreamId stream_id,
                                        uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode);
 
-UXRDLLAPI uint16_t uxr_buffer_configure_subscriber_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_subscriber_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode);
 
-UXRDLLAPI uint16_t uxr_buffer_configure_datawriter_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_datawriter_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId publisher_id, const char* xml, uint8_t mode);
 
-UXRDLLAPI uint16_t uxr_buffer_configure_datareader_xml(uxrSession* session, uxrStreamId stream_id,
+UXRDLLAPI uint16_t uxr_buffer_create_datareader_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId subscriber_id, const char* xml, uint8_t mode);
 
 #ifdef __cplusplus

--- a/src/c/profile/session/create_entities_xml.c
+++ b/src/c/profile/session/create_entities_xml.c
@@ -12,7 +12,7 @@ static uint16_t create_entity_xml(uxrSession* session, uxrStreamId stream_id,
 //==================================================================
 //                              PUBLIC
 //==================================================================
-uint16_t uxr_buffer_configure_participant_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_participant_xml(uxrSession* session, uxrStreamId stream_id,
                                          uxrObjectId object_id, uint16_t domain, const char* xml, uint8_t mode)
 {
     //assert with the object_id type
@@ -24,7 +24,7 @@ uint16_t uxr_buffer_configure_participant_xml(uxrSession* session, uxrStreamId s
     return create_entity_xml(session, stream_id, object_id, xml, mode, &payload);
 }
 
-uint16_t uxr_buffer_configure_topic_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_topic_xml(uxrSession* session, uxrStreamId stream_id,
                                    uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode)
 {
     //assert with the object_id type
@@ -36,7 +36,7 @@ uint16_t uxr_buffer_configure_topic_xml(uxrSession* session, uxrStreamId stream_
     return create_entity_xml(session, stream_id, object_id, xml, mode, &payload);
 }
 
-uint16_t uxr_buffer_configure_publisher_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_publisher_xml(uxrSession* session, uxrStreamId stream_id,
                                        uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode)
 {
     //assert with the object_id type
@@ -48,7 +48,7 @@ uint16_t uxr_buffer_configure_publisher_xml(uxrSession* session, uxrStreamId str
     return create_entity_xml(session, stream_id, object_id, xml, mode, &payload);
 }
 
-uint16_t uxr_buffer_configure_subscriber_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_subscriber_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId participant_id, const char* xml, uint8_t mode)
 {
     //assert with the object_id type
@@ -60,7 +60,7 @@ uint16_t uxr_buffer_configure_subscriber_xml(uxrSession* session, uxrStreamId st
     return create_entity_xml(session, stream_id, object_id, xml, mode, &payload);
 }
 
-uint16_t uxr_buffer_configure_datawriter_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_datawriter_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId publisher_id, const char* xml, uint8_t mode)
 {
     //assert with the object_id type
@@ -72,7 +72,7 @@ uint16_t uxr_buffer_configure_datawriter_xml(uxrSession* session, uxrStreamId st
     return create_entity_xml(session, stream_id, object_id, xml, mode, &payload);
 }
 
-uint16_t uxr_buffer_configure_datareader_xml(uxrSession* session, uxrStreamId stream_id,
+uint16_t uxr_buffer_create_datareader_xml(uxrSession* session, uxrStreamId stream_id,
                                         uxrObjectId object_id, uxrObjectId subscriber_id, const char* xml, uint8_t mode)
 {
     //assert with the object_id type

--- a/test/integration/interaction/ClientInteraction.hpp
+++ b/test/integration/interaction/ClientInteraction.hpp
@@ -47,31 +47,31 @@ public:
         ASSERT_EQ(expected_status, status);
 
         uxrObjectId topic_id = uxr_object_id(id, UXR_TOPIC_ID);
-        request_id = uxr_buffer_configure_topic_xml(&session_, output_stream_id, topic_id, participant_id, topic_xml_, flags);
+        request_id = uxr_buffer_create_topic_xml(&session_, output_stream_id, topic_id, participant_id, topic_xml_, flags);
         ASSERT_NE(UXR_INVALID_REQUEST_ID, request_id);
         uxr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         uxrObjectId publisher_id = uxr_object_id(id, UXR_PUBLISHER_ID);
-        request_id = uxr_buffer_configure_publisher_xml(&session_, output_stream_id, publisher_id, participant_id, publisher_xml_, flags);
+        request_id = uxr_buffer_create_publisher_xml(&session_, output_stream_id, publisher_id, participant_id, publisher_xml_, flags);
         ASSERT_NE(UXR_INVALID_REQUEST_ID, request_id);
         uxr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         uxrObjectId datawriter_id = uxr_object_id(id, UXR_DATAWRITER_ID);
-        request_id = uxr_buffer_configure_datawriter_xml(&session_, output_stream_id, datawriter_id, publisher_id, datawriter_xml_, flags);
+        request_id = uxr_buffer_create_datawriter_xml(&session_, output_stream_id, datawriter_id, publisher_id, datawriter_xml_, flags);
         ASSERT_NE(UXR_INVALID_REQUEST_ID, request_id);
         uxr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         uxrObjectId subscriber_id = uxr_object_id(id, UXR_SUBSCRIBER_ID);
-        request_id = uxr_buffer_configure_subscriber_xml(&session_, output_stream_id, subscriber_id, participant_id, subscriber_xml_, flags);
+        request_id = uxr_buffer_create_subscriber_xml(&session_, output_stream_id, subscriber_id, participant_id, subscriber_xml_, flags);
         ASSERT_NE(UXR_INVALID_REQUEST_ID, request_id);
         uxr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);
 
         uxrObjectId datareader_id = uxr_object_id(id, UXR_DATAREADER_ID);
-        request_id = uxr_buffer_configure_datareader_xml(&session_, output_stream_id, datareader_id, subscriber_id, datareader_xml_, flags);
+        request_id = uxr_buffer_create_datareader_xml(&session_, output_stream_id, datareader_id, subscriber_id, datareader_xml_, flags);
         ASSERT_NE(UXR_INVALID_REQUEST_ID, request_id);
         uxr_run_session_until_all_status(&session_, 60000, &request_id, &status, 1);
         ASSERT_EQ(expected_status, status);

--- a/test/memory/consumption/MemoryConsumption.c
+++ b/test/memory/consumption/MemoryConsumption.c
@@ -68,23 +68,23 @@ int main()
 
     uxrObjectId topic_id = uxr_object_id(0x01, UXR_TOPIC_ID);
     const char* topic_xml = "<dds><topic><name>HelloWorldTopic</name><dataType>HelloWorld</dataType></topic></dds>";
-    uint16_t topic_req = uxr_buffer_configure_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
+    uint16_t topic_req = uxr_buffer_create_topic_xml(&session, reliable_out, topic_id, participant_id, topic_xml, UXR_REPLACE);
 
     uxrObjectId publisher_id = uxr_object_id(0x01, UXR_PUBLISHER_ID);
     const char* publisher_xml = "<publisher name=\"MyPublisher\">";
-    uint16_t publisher_req = uxr_buffer_configure_publisher_xml(&session, reliable_out, publisher_id, participant_id, publisher_xml, UXR_REPLACE);
+    uint16_t publisher_req = uxr_buffer_create_publisher_xml(&session, reliable_out, publisher_id, participant_id, publisher_xml, UXR_REPLACE);
 
     uxrObjectId datawriter_id = uxr_object_id(0x01, UXR_DATAWRITER_ID);
     const char* datawriter_xml = "<profiles><publisher profile_name=\"default_xrce_publisher_profile\"><topic><kind>NO_KEY</kind><name>HelloWorldTopic</name><dataType>HelloWorld</dataType><historyQos><kind>KEEP_LAST</kind><depth>5</depth></historyQos><durability><kind>TRANSIENT_LOCAL</kind></durability></topic></publisher></profiles>";
-    uint16_t datawriter_req = uxr_buffer_configure_datawriter_xml(&session, reliable_out, datawriter_id, publisher_id, datawriter_xml, UXR_REPLACE);
+    uint16_t datawriter_req = uxr_buffer_create_datawriter_xml(&session, reliable_out, datawriter_id, publisher_id, datawriter_xml, UXR_REPLACE);
 
     uxrObjectId subscriber_id = uxr_object_id(0x01, UXR_SUBSCRIBER_ID);
     const char* subscriber_xml = "<subscriber name=\"MySubscriber\">";
-    uint16_t subscriber_req = uxr_buffer_configure_subscriber_xml(&session, reliable_out, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
+    uint16_t subscriber_req = uxr_buffer_create_subscriber_xml(&session, reliable_out, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
 
     uxrObjectId datareader_id = uxr_object_id(0x01, UXR_DATAREADER_ID);
     const char* datareader_xml = "<profiles><subscriber profile_name=\"default_xrce_subscriber_profile\"><topic><kind>NO_KEY</kind><name>HelloWorldTopic</name><dataType>HelloWorld</dataType><historyQos><kind>KEEP_LAST</kind><depth>5</depth></historyQos><durability><kind>TRANSIENT_LOCAL</kind></durability></topic></subscriber></profiles>";
-    uint16_t datareader_req = uxr_buffer_configure_datareader_xml(&session, reliable_out, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
+    uint16_t datareader_req = uxr_buffer_create_datareader_xml(&session, reliable_out, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
 
     uint8_t status[6];
     uint16_t request[6] = {participant_req, topic_req, publisher_req, datawriter_req, subscriber_req, datareader_req};


### PR DESCRIPTION
The configure functions, at this moment, not only configure the xrce objects, they also create them. In this context, the configure word can be confused. Besides, with the addition of create by ref functions, is more probably that the user thinks that the configure functions only configure and the create only create, when not.