### PR TITLE
Fixed limit case bug in output streams

### DIFF
--- a/src/c/core/session/stream/output_best_effort_stream.c
+++ b/src/c/core/session/stream/output_best_effort_stream.c
@@ -1,4 +1,6 @@
 #include "output_best_effort_stream_internal.h"
+
+#include "../submessage_internal.h"
 #include "seq_num_internal.h"
 
 #include <ucdr/microcdr.h>
@@ -23,10 +25,13 @@ void uxr_reset_output_best_effort_stream(uxrOutputBestEffortStream* stream)
 
 bool uxr_prepare_best_effort_buffer_to_write(uxrOutputBestEffortStream* stream, size_t size, ucdrBuffer* mb)
 {
-    bool available_to_write = stream->writer + size <= stream->size;
+
+    size_t current_padding = uxr_submessage_padding(stream->writer);
+    size_t future_length = stream->writer + current_padding + size;
+    bool available_to_write = future_length <= stream->size;
     if(available_to_write)
     {
-        ucdr_init_buffer_offset(mb, stream->buffer, (uint32_t)(stream->writer + size), (uint32_t)stream->writer);
+        ucdr_init_buffer_offset(mb, stream->buffer, (uint32_t)future_length, (uint32_t)(stream->writer + current_padding));
         stream->writer += size;
     }
 

--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -1,10 +1,11 @@
-#include <uxr/client/config.h>
-#include <string.h>
+#include "output_reliable_stream_internal.h"
 
 #include "seq_num_internal.h"
-#include "output_reliable_stream_internal.h"
 #include "../submessage_internal.h"
 #include "../../serialization/xrce_protocol_internal.h"
+
+#include <uxr/client/config.h>
+#include <string.h>
 
 // Remove when Microcdr supports size_of functions
 #define HEARTBEAT_PAYLOAD_SIZE 4
@@ -81,10 +82,10 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
     if(available_to_write)
     {
         size_t current_length = uxr_get_output_buffer_length(internal_buffer);
-        size_t current_padding = (current_length % 4 != 0) ? 4 - (current_length % 4) : 0;
+        size_t current_padding = uxr_submessage_padding(current_length);
         size_t future_length = current_length + current_padding + size;
         uxr_set_output_buffer_length(internal_buffer, future_length);
-        ucdr_init_buffer_offset(mb, internal_buffer, (uint32_t)future_length, (uint32_t)current_length);
+        ucdr_init_buffer_offset(mb, internal_buffer, (uint32_t)future_length, (uint32_t)(current_length + current_padding));
     }
 
     return available_to_write;


### PR DESCRIPTION
- When the submessages are appending to the stream, the control to allow or not the stream for a specific submessage size did not take into account the possible submessage offset that can occur during the serialization.

- Minor issue in a reliable output buffer related with the submessage padding.

A merge with develop is necessary after accepting this PR.