### PR TITLE
Refactored and removed submessage concept from streams.

### DIFF
--- a/include/uxr/client/core/session/stream/output_reliable_stream.h
+++ b/include/uxr/client/core/session/stream/output_reliable_stream.h
@@ -25,8 +25,6 @@ extern "C"
 #include <stddef.h>
 #include <stdbool.h>
 
-struct ucdrBuffer;
-
 typedef struct uxrOutputReliableStream
 {
     uint8_t* buffer;

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -355,6 +355,7 @@ void write_submessage_heartbeat(const uxrSession* session, uxrStreamId id)
 
     const uxrOutputReliableStream* stream = &session->streams.output_reliable[id.index];
 
+    uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_HEARTBEAT, HEARTBEAT_PAYLOAD_SIZE, 0);
     uxr_buffer_heartbeat(stream, &ub);
     uxr_stamp_session_header(&session->info, 0, id.raw, ub.init);
     send_message(session, heartbeat_buffer, ucdr_buffer_length(&ub));
@@ -368,6 +369,7 @@ void write_submessage_acknack(const uxrSession* session, uxrStreamId id)
 
     const uxrInputReliableStream* stream = &session->streams.input_reliable[id.index];
 
+    uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_ACKNACK, ACKNACK_PAYLOAD_SIZE, 0);
     uxr_buffer_acknack(stream, &ub);
     uxr_stamp_session_header(&session->info, 0, id.raw, ub.init);
     send_message(session, acknack_buffer, ucdr_buffer_length(&ub));

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -565,8 +565,7 @@ void process_status(uxrSession* session, uxrObjectId object_id, uint16_t request
 
 bool uxr_prepare_stream_to_write_submessage(uxrSession* session, uxrStreamId stream_id, size_t payload_size, ucdrBuffer* ub, uint8_t submessage_id, uint8_t mode)
 {
-    size_t current_stream_length = uxr_output_stream_current_length(&session->streams, stream_id);
-    size_t submessage_size = (uxr_submessage_padding(current_stream_length) + SUBHEADER_SIZE + payload_size);
+    size_t submessage_size = SUBHEADER_SIZE + payload_size + uxr_submessage_padding(payload_size);
     bool prepared = uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)submessage_size, ub);
     if(prepared)
     {

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -562,3 +562,17 @@ void process_status(uxrSession* session, uxrObjectId object_id, uint16_t request
         }
     }
 }
+
+bool uxr_prepare_stream_to_write_submessage(uxrSession* session, uxrStreamId stream_id, size_t payload_size, ucdrBuffer* ub, uint8_t submessage_id, uint8_t mode)
+{
+    size_t current_stream_length = uxr_output_stream_current_length(&session->streams, stream_id);
+    size_t submessage_size = (uxr_submessage_padding(current_stream_length) + SUBHEADER_SIZE + payload_size);
+    bool prepared = uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)submessage_size, ub);
+    if(prepared)
+    {
+        (void) uxr_buffer_submessage_header(ub, submessage_id, (uint16_t)payload_size, mode);
+    }
+
+    return prepared;
+}
+

--- a/src/c/core/session/session_internal.h
+++ b/src/c/core/session/session_internal.h
@@ -1,0 +1,39 @@
+// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _SRC_C_CORE_SESSION_SESSION_INTERNAL_H_
+#define _SRC_C_CORE_SESSION_SESSION_INTERNAL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <uxr/client/core/session/session.h>
+
+struct ucdrBuffer;
+
+bool uxr_prepare_stream_to_write_submessage(uxrSession* session,
+                                            uxrStreamId stream_id,
+                                            size_t payload_size,
+                                            struct ucdrBuffer* ub,
+                                            uint8_t submessage_id,
+                                            uint8_t mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _SRC_C_CORE_SESSION_SESSION_INTERNAL_H_
+

--- a/src/c/core/session/stream/input_reliable_stream.c
+++ b/src/c/core/session/stream/input_reliable_stream.c
@@ -1,13 +1,8 @@
 #include "seq_num_internal.h"
 #include "input_reliable_stream_internal.h"
-#include "../submessage_internal.h"
 #include "../../serialization/xrce_protocol_internal.h"
 
 #include <string.h>
-
-// Remove when Microcdr supports size_of functions
-#define ACKNACK_PAYLOAD_SIZE     4
-//---
 
 #define INTERNAL_BUFFER_OFFSET  sizeof(size_t)
 
@@ -100,7 +95,10 @@ bool uxr_next_input_reliable_buffer_available(uxrInputReliableStream* stream, uc
     return available_to_read;
 }
 
-void uxr_buffer_acknack(const uxrInputReliableStream* stream, ucdrBuffer* ub) {
+void uxr_buffer_acknack(const uxrInputReliableStream* stream, ucdrBuffer* ub)
+{
+    (void) stream; (void) ub;
+
     uint16_t nack_bitmap = compute_nack_bitmap(stream);
 
     ACKNACK_Payload payload;
@@ -108,9 +106,7 @@ void uxr_buffer_acknack(const uxrInputReliableStream* stream, ucdrBuffer* ub) {
     payload.nack_bitmap[0] = (uint8_t)(nack_bitmap >> 8);
     payload.nack_bitmap[1] = (uint8_t)((nack_bitmap << 8) >> 8);
 
-    (void) uxr_buffer_submessage_header(ub, SUBMESSAGE_ID_ACKNACK, ACKNACK_PAYLOAD_SIZE, 0);
     (void) uxr_serialize_ACKNACK_Payload(ub, &payload);
-    (void) stream; (void) ub;
 }
 
 void uxr_read_heartbeat(uxrInputReliableStream* stream, ucdrBuffer* payload)

--- a/src/c/core/session/stream/input_reliable_stream_internal.h
+++ b/src/c/core/session/stream/input_reliable_stream_internal.h
@@ -26,6 +26,8 @@ extern "C"
 #include <stdbool.h>
 #include <stddef.h>
 
+#define ACKNACK_PAYLOAD_SIZE     4
+
 struct ucdrBuffer;
 
 void uxr_init_input_reliable_stream(uxrInputReliableStream* stream, uint8_t* buffer, size_t size, uint16_t history);

--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -3,7 +3,6 @@
 
 #include "seq_num_internal.h"
 #include "output_reliable_stream_internal.h"
-#include "../submessage_internal.h"
 #include "../../serialization/xrce_protocol_internal.h"
 
 #define MIN_HEARTBEAT_TIME_INTERVAL ((int64_t) UXR_CONFIG_MIN_HEARTBEAT_TIME_INTERVAL) // ms
@@ -46,6 +45,12 @@ void uxr_reset_output_reliable_stream(uxrOutputReliableStream* stream)
     stream->send_lost = false;
 }
 
+size_t uxr_output_buffer_current_length(uxrOutputReliableStream* stream)
+{
+    uint8_t* internal_buffer = uxr_get_output_buffer(stream, stream->last_written % stream->history);
+    return uxr_get_output_buffer_length(internal_buffer);
+}
+
 bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_t size, ucdrBuffer* ub)
 {
     bool available_to_write = false;
@@ -54,7 +59,7 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
     size_t length = uxr_get_output_buffer_length(internal_buffer);
 
     /* Check if the message fit in the current buffer */
-    if(length + uxr_submessage_padding(length) + size <= uxr_get_output_buffer_size(stream))
+    if(length + size <= uxr_get_output_buffer_size(stream))
     {
         /* Check if there is space in the stream history to write */
         uxrSeqNum last_available = uxr_seq_num_add(stream->last_acknown, stream->history);
@@ -77,8 +82,7 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
     if(available_to_write)
     {
         size_t current_length = uxr_get_output_buffer_length(internal_buffer);
-        size_t current_padding = (current_length % 4 != 0) ? 4 - (current_length % 4) : 0;
-        size_t future_length = current_length + current_padding + size;
+        size_t future_length = current_length + size;
         uxr_set_output_buffer_length(internal_buffer, future_length);
         ucdr_init_buffer_offset(ub, internal_buffer, (uint32_t)future_length, (uint32_t)current_length);
     }

--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -6,10 +6,6 @@
 #include "../submessage_internal.h"
 #include "../../serialization/xrce_protocol_internal.h"
 
-// Remove when Microcdr supports size_of functions
-#define HEARTBEAT_PAYLOAD_SIZE 4
-//---
-
 #define MIN_HEARTBEAT_TIME_INTERVAL ((int64_t) UXR_CONFIG_MIN_HEARTBEAT_TIME_INTERVAL) // ms
 
 #define MAX_HEARTBEAT_TRIES (sizeof(int64_t) * 8 - 1)
@@ -175,7 +171,6 @@ void uxr_buffer_heartbeat(const uxrOutputReliableStream* stream, ucdrBuffer* ub)
     payload.first_unacked_seq_nr = uxr_seq_num_add(stream->last_acknown, 1);
     payload.last_unacked_seq_nr = stream->last_sent;
 
-    (void) uxr_buffer_submessage_header(ub, SUBMESSAGE_ID_HEARTBEAT, HEARTBEAT_PAYLOAD_SIZE, 0);
     (void) uxr_serialize_HEARTBEAT_Payload(ub, &payload);
 }
 

--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -45,12 +45,6 @@ void uxr_reset_output_reliable_stream(uxrOutputReliableStream* stream)
     stream->send_lost = false;
 }
 
-size_t uxr_output_buffer_current_length(uxrOutputReliableStream* stream)
-{
-    uint8_t* internal_buffer = uxr_get_output_buffer(stream, stream->last_written % stream->history);
-    return uxr_get_output_buffer_length(internal_buffer);
-}
-
 bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_t size, ucdrBuffer* ub)
 {
     bool available_to_write = false;

--- a/src/c/core/session/stream/output_reliable_stream_internal.h
+++ b/src/c/core/session/stream/output_reliable_stream_internal.h
@@ -41,6 +41,7 @@ bool uxr_next_reliable_nack_buffer_to_send(uxrOutputReliableStream* stream, uint
 void uxr_buffer_heartbeat(const uxrOutputReliableStream* stream, struct ucdrBuffer* ub);
 void uxr_read_acknack(uxrOutputReliableStream* stream, struct ucdrBuffer* payload);
 
+size_t uxr_output_buffer_current_length(uxrOutputReliableStream* stream);
 bool uxr_is_output_reliable_stream_busy(const uxrOutputReliableStream* stream);
 
 size_t uxr_get_output_buffer_length(uint8_t* buffer);

--- a/src/c/core/session/stream/output_reliable_stream_internal.h
+++ b/src/c/core/session/stream/output_reliable_stream_internal.h
@@ -26,6 +26,10 @@ extern "C"
 #include <stddef.h>
 #include <stdbool.h>
 
+#define HEARTBEAT_PAYLOAD_SIZE 4
+
+struct ucdrBuffer;
+
 void uxr_init_output_reliable_stream(uxrOutputReliableStream* stream, uint8_t* buffer, size_t size, uint16_t history, uint8_t header_offset);
 void uxr_reset_output_reliable_stream(uxrOutputReliableStream* stream);
 bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_t size, struct ucdrBuffer* ub);

--- a/src/c/core/session/stream/output_reliable_stream_internal.h
+++ b/src/c/core/session/stream/output_reliable_stream_internal.h
@@ -41,7 +41,6 @@ bool uxr_next_reliable_nack_buffer_to_send(uxrOutputReliableStream* stream, uint
 void uxr_buffer_heartbeat(const uxrOutputReliableStream* stream, struct ucdrBuffer* ub);
 void uxr_read_acknack(uxrOutputReliableStream* stream, struct ucdrBuffer* payload);
 
-size_t uxr_output_buffer_current_length(uxrOutputReliableStream* stream);
 bool uxr_is_output_reliable_stream_busy(const uxrOutputReliableStream* stream);
 
 size_t uxr_get_output_buffer_length(uint8_t* buffer);

--- a/src/c/core/session/stream/stream_storage.c
+++ b/src/c/core/session/stream/stream_storage.c
@@ -1,4 +1,3 @@
-
 #include "stream_storage_internal.h"
 #include "input_best_effort_stream_internal.h"
 #include "input_reliable_stream_internal.h"
@@ -109,6 +108,28 @@ uxrInputReliableStream* uxr_get_input_reliable_stream(uxrStreamStorage* storage,
         return &storage->input_reliable[index];
     }
     return NULL;
+}
+
+size_t uxr_output_stream_current_length(uxrStreamStorage* storage, uxrStreamId stream_id)
+{
+    switch(stream_id.type)
+    {
+        case UXR_BEST_EFFORT_STREAM:
+        {
+            uxrOutputBestEffortStream* stream = uxr_get_output_best_effort_stream(storage, stream_id.index);
+            return stream->writer;
+            break;
+        }
+        case UXR_RELIABLE_STREAM:
+        {
+            uxrOutputReliableStream* stream = uxr_get_output_reliable_stream(storage, stream_id.index);
+            return uxr_output_buffer_current_length(stream);
+            break;
+        }
+        default:
+            return SIZE_MAX; //some kind of error?
+            break;
+    }
 }
 
 bool uxr_prepare_stream_to_write(uxrStreamStorage* storage, uxrStreamId stream_id, size_t size, struct ucdrBuffer* ub)

--- a/src/c/core/session/stream/stream_storage.c
+++ b/src/c/core/session/stream/stream_storage.c
@@ -110,28 +110,6 @@ uxrInputReliableStream* uxr_get_input_reliable_stream(uxrStreamStorage* storage,
     return NULL;
 }
 
-size_t uxr_output_stream_current_length(uxrStreamStorage* storage, uxrStreamId stream_id)
-{
-    switch(stream_id.type)
-    {
-        case UXR_BEST_EFFORT_STREAM:
-        {
-            uxrOutputBestEffortStream* stream = uxr_get_output_best_effort_stream(storage, stream_id.index);
-            return stream->writer;
-            break;
-        }
-        case UXR_RELIABLE_STREAM:
-        {
-            uxrOutputReliableStream* stream = uxr_get_output_reliable_stream(storage, stream_id.index);
-            return uxr_output_buffer_current_length(stream);
-            break;
-        }
-        default:
-            return SIZE_MAX; //some kind of error?
-            break;
-    }
-}
-
 bool uxr_prepare_stream_to_write(uxrStreamStorage* storage, uxrStreamId stream_id, size_t size, struct ucdrBuffer* ub)
 {
     bool available = false;

--- a/src/c/core/session/stream/stream_storage_internal.h
+++ b/src/c/core/session/stream/stream_storage_internal.h
@@ -46,6 +46,7 @@ uxrOutputReliableStream* uxr_get_output_reliable_stream(uxrStreamStorage* storag
 uxrInputBestEffortStream* uxr_get_input_best_effort_stream(uxrStreamStorage* storage, uint8_t index);
 uxrInputReliableStream* uxr_get_input_reliable_stream(uxrStreamStorage* storage, uint8_t index);
 
+size_t uxr_output_stream_current_length(uxrStreamStorage* storage, uxrStreamId stream_id);
 bool uxr_prepare_stream_to_write(uxrStreamStorage* storage, uxrStreamId stream_id, size_t size, struct ucdrBuffer* ub);
 bool uxr_output_streams_confirmed(const uxrStreamStorage* storage);
 

--- a/src/c/core/session/stream/stream_storage_internal.h
+++ b/src/c/core/session/stream/stream_storage_internal.h
@@ -46,7 +46,6 @@ uxrOutputReliableStream* uxr_get_output_reliable_stream(uxrStreamStorage* storag
 uxrInputBestEffortStream* uxr_get_input_best_effort_stream(uxrStreamStorage* storage, uint8_t index);
 uxrInputReliableStream* uxr_get_input_reliable_stream(uxrStreamStorage* storage, uint8_t index);
 
-size_t uxr_output_stream_current_length(uxrStreamStorage* storage, uxrStreamId stream_id);
 bool uxr_prepare_stream_to_write(uxrStreamStorage* storage, uxrStreamId stream_id, size_t size, struct ucdrBuffer* ub);
 bool uxr_output_streams_confirmed(const uxrStreamStorage* storage);
 

--- a/src/c/profile/session/common_create_entities.c
+++ b/src/c/profile/session/common_create_entities.c
@@ -1,5 +1,5 @@
 #include "common_create_entities_internal.h"
-#include "../../core/session/stream/stream_storage_internal.h"
+#include "../../core/session/session_internal.h"
 #include "../../core/session/session_info_internal.h"
 #include "../../core/session/submessage_internal.h"
 #include "../../core/serialization/xrce_protocol_internal.h"
@@ -14,14 +14,12 @@ uint16_t uxr_buffer_delete_entity(uxrSession* session, uxrStreamId stream_id, ux
     DELETE_Payload payload;
 
     // Change this when microcdr supports size_of function.
-    uint16_t payload_length = 0; //DELETE_Payload_size(&payload);
+    size_t payload_length = 0; //DELETE_Payload_size(&payload);
     payload_length = (uint16_t)(payload_length + 4); // delete payload (request id + object_id), no padding.
 
     ucdrBuffer ub;
-    if(uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(payload_length + SUBHEADER_SIZE), &ub))
+    if(uxr_prepare_stream_to_write_submessage(session, stream_id, payload_length, &ub, SUBMESSAGE_ID_DELETE, 0))
     {
-        (void) uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_DELETE, payload_length, 0);
-
         request_id = uxr_init_base_object_request(&session->info, object_id, &payload.base);
         (void) uxr_serialize_DELETE_Payload(&ub, &payload);
     }
@@ -36,7 +34,7 @@ uint16_t uxr_common_create_entity(uxrSession* session, uxrStreamId stream_id,
     uint16_t request_id = UXR_INVALID_REQUEST_ID;
 
     // Change this when microcdr supports size_of function. Currently, DOMAIN_ID is not supported.
-    uint16_t payload_length = 0; //CREATE_Payload_size(&payload);
+    size_t payload_length = 0; //CREATE_Payload_size(&payload);
     payload_length = (uint16_t)(payload_length + 4); // base
     payload_length = (uint16_t)(payload_length + 1); // objk type
     payload_length = (uint16_t)(payload_length + 1); // base3 type => xml
@@ -47,10 +45,9 @@ uint16_t uxr_common_create_entity(uxrSession* session, uxrStreamId stream_id,
     payload_length = (uint16_t)(payload_length + 2); //object id ref
 
     ucdrBuffer ub;
-    if(uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(payload_length + SUBHEADER_SIZE), &ub))
+    if(uxr_prepare_stream_to_write_submessage(session, stream_id, payload_length, &ub, SUBMESSAGE_ID_CREATE, mode))
     {
         request_id = uxr_init_base_object_request(&session->info, object_id, &payload->base);
-        (void) uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_CREATE, payload_length, mode);
         (void) uxr_serialize_CREATE_Payload(&ub, payload);
     }
 

--- a/src/c/profile/session/read_access.c
+++ b/src/c/profile/session/read_access.c
@@ -1,6 +1,6 @@
 #include <uxr/client/profile/session/read_access.h>
 
-#include "../../core/session/stream/stream_storage_internal.h"
+#include "../../core/session/session_internal.h"
 #include "../../core/session/session_info_internal.h"
 #include "../../core/session/submessage_internal.h"
 #include "../../core/serialization/xrce_protocol_internal.h"
@@ -41,16 +41,14 @@ uint16_t uxr_buffer_request_data(uxrSession* session, uxrStreamId stream_id, uxr
     }
 
     // Change this when microcdr supports size_of function.
-    uint16_t payload_length = 0; //READ_DATA_Payload_size(&payload);
+    size_t payload_length = 0; //READ_DATA_Payload_size(&payload);
     payload_length = (uint16_t)(payload_length + 4); // (request id + object_id), no padding.
     payload_length = (uint16_t)(payload_length + 4); // stream, format, and two optionals.
     payload_length = (uint16_t)(payload_length + ((control != NULL) ? 8 : 0)); // delivery control
 
     ucdrBuffer ub;
-    if(uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(payload_length + SUBHEADER_SIZE), &ub))
+    if(uxr_prepare_stream_to_write_submessage(session, stream_id, payload_length, &ub, SUBMESSAGE_ID_READ_DATA, 0))
     {
-        (void) uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_READ_DATA, payload_length, 0);
-
         request_id = uxr_init_base_object_request(&session->info, datareader_id, &payload.base);
         (void) uxr_serialize_READ_DATA_Payload(&ub, &payload);
     }

--- a/src/c/profile/session/write_access.c
+++ b/src/c/profile/session/write_access.c
@@ -1,6 +1,6 @@
 #include <uxr/client/profile/session/write_access.h>
 
-#include "../../core/session/stream/stream_storage_internal.h"
+#include "../../core/session/session_internal.h"
 #include "../../core/session/session_info_internal.h"
 #include "../../core/session/submessage_internal.h"
 #include "../../core/serialization/xrce_protocol_internal.h"
@@ -14,12 +14,10 @@ bool uxr_prepare_output_stream(uxrSession* session, uxrStreamId stream_id, uxrOb
                               struct ucdrBuffer* ub_topic, uint32_t topic_size)
 {
     ucdrBuffer ub;
-    size_t submessage_size = SUBHEADER_SIZE + WRITE_DATA_PAYLOAD_SIZE + topic_size;
-    if(uxr_prepare_stream_to_write(&session->streams, stream_id, submessage_size, &ub))
+    size_t payload_size = WRITE_DATA_PAYLOAD_SIZE + topic_size;
+    if(uxr_prepare_stream_to_write_submessage(session, stream_id, payload_size,
+                                              &ub, SUBMESSAGE_ID_WRITE_DATA, FORMAT_DATA))
     {
-        uint16_t payload_size = (uint16_t)(WRITE_DATA_PAYLOAD_SIZE + topic_size);
-        (void) uxr_buffer_submessage_header(&ub, SUBMESSAGE_ID_WRITE_DATA, payload_size, FORMAT_DATA);
-
         WRITE_DATA_Payload_Data payload;
         uxr_init_base_object_request(&session->info, datawriter_id, &payload.base);
         (void) uxr_serialize_WRITE_DATA_Payload_Data(&ub, &payload);


### PR DESCRIPTION
The `stream` package had a dependency of submessage contained into the `core` package (see core diagram of internal docs). The `stream` package must not contain any of the `core` package in order to keep the concepts separately.

To fix this, a refactorization of `prepare_stream_buffer` function was done, adding a "new one" in the session level to manage the submessage logic.

This PR override the hotfix https://github.com/eProsima/Micro-XRCE-DDS-Client/pull/50 with a better approach.

> Integration test was performed over this PR successfully.