### PR TITLE
Performance test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ option(VERBOSE_SERIALIZATION "Use verbose output" OFF)
 option(VERBOSE_MESSAGE "Use verbose output" OFF)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(MEMORY_PERFORMANCE "Memory performace test." OFF)
-    option(PERFORMANCE_TEST "Performance testing." OFF)
+    option(PERFORMANCE_TESTS "Performance testing." OFF)
 endif()
 
 if(EPROSIMA_BUILD)
@@ -66,7 +66,7 @@ if(EPROSIMA_BUILD)
 endif()
 
 if(EPROSIMA_BUILD_TESTS)
-    set(PERFORMANCE_TEST ON)
+    set(PERFORMANCE_TESTS ON)
 endif()
 
 ###############################################################################
@@ -241,10 +241,11 @@ configure_file(${PROJECT_SOURCE_DIR}/include/uxr/client/config.h.in
 
 # Definitions
 target_compile_definitions(${PROJECT_NAME}
+    PUBLIC
+        $<$<BOOL:${PERFORMANCE_TESTS}>:PERFORMANCE_TESTING>
     PRIVATE
         $<$<BOOL:${VERBOSE_SERIALIZATION}>:UXR_SERIALIZATION_LOGS>
         $<$<BOOL:${VERBOSE_MESSAGE}>:UXR_MESSAGE_LOGS>
-        $<$<BOOL:${PERFORMANCE_TEST}>:PERFORMANCE_TESTING>
     )
 
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,17 @@ option(VERBOSE_SERIALIZATION "Use verbose output" OFF)
 option(VERBOSE_MESSAGE "Use verbose output" OFF)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(MEMORY_PERFORMANCE "Memory performace test." OFF)
+    option(PERFORMANCE_TEST "Performance testing." OFF)
 endif()
 
 if(EPROSIMA_BUILD)
     set(EPROSIMA_BUILD_EXAMPLES ON)
     set(EPROSIMA_BUILD_TESTS ON)
     set(THIRDPARTY ON)
+endif()
+
+if(EPROSIMA_BUILD_TESTS)
+    set(PERFORMANCE_TEST ON)
 endif()
 
 ###############################################################################
@@ -239,6 +244,7 @@ target_compile_definitions(${PROJECT_NAME}
     PRIVATE
         $<$<BOOL:${VERBOSE_SERIALIZATION}>:UXR_SERIALIZATION_LOGS>
         $<$<BOOL:${VERBOSE_MESSAGE}>:UXR_MESSAGE_LOGS>
+        $<$<BOOL:${PERFORMANCE_TEST}>:PERFORMANCE_TESTING>
     )
 
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)

--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -34,7 +34,8 @@ typedef void (*uxrOnTopicFunc) (struct uxrSession* session, uxrObjectId object_i
                              uxrStreamId stream_id, struct ucdrBuffer* ub, void* args);
 
 #ifdef PERFORMANCE_TESTING
-typedef void (*uxrOnEchoFunc) (struct uxrSession* session, uint16_t request_id);
+typedef void (*uxrOnPerformanceFunc) (struct uxrSession* session, uint64_t epoch_time, uint16_t length,
+                                      struct ucdrBuffer* mb, void* args);
 #endif
 
 typedef struct uxrSession
@@ -54,7 +55,8 @@ typedef struct uxrSession
     void* on_topic_args;
 
 #ifdef PERFORMANCE_TESTING
-    uxrOnEchoFunc on_echo;
+    uxrOnPerformanceFunc on_performance;
+    void* on_performance_args;
 #endif
 
 } uxrSession;
@@ -66,7 +68,7 @@ UXRDLLAPI void uxr_init_session(uxrSession* session, struct uxrCommunication* co
 UXRDLLAPI void uxr_set_status_callback(uxrSession* session, uxrOnStatusFunc on_status_func, void* args);
 UXRDLLAPI void uxr_set_topic_callback(uxrSession* session, uxrOnTopicFunc on_topic_func, void* args);
 #ifdef PERFORMANCE_TESTING
-UXRDLLAPI void uxr_set_echo_callback(uxrSession* session, uxrOnEchoFunc on_echo_func);
+UXRDLLAPI void uxr_set_performance_callback(uxrSession* session, uxrOnPerformanceFunc on_performance_func, void* args);
 #endif
 
 UXRDLLAPI bool uxr_create_session(uxrSession* session);
@@ -85,8 +87,12 @@ UXRDLLAPI bool uxr_run_session_until_all_status(uxrSession* session, int timeout
 UXRDLLAPI bool uxr_run_session_until_one_status(uxrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
 
 #ifdef PERFORMANCE_TESTING
-UXRDLLAPI uint16_t uxr_buffer_echo(uxrSession* session, uxrStreamId stream_id);
-UXRDLLAPI bool uxr_buffer_throughput(uxrSession* session, uxrStreamId stream_id, uint8_t* buf, uint32_t size);
+UXRDLLAPI bool uxr_buffer_performance(uxrSession* session,
+                                      uxrStreamId stream_id,
+                                      uint64_t epoch_time,
+                                      uint8_t* buf,
+                                      uint16_t len,
+                                      bool echo);
 #endif
 
 #ifdef __cplusplus

--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -34,8 +34,7 @@ typedef void (*uxrOnTopicFunc) (struct uxrSession* session, uxrObjectId object_i
                              uxrStreamId stream_id, struct ucdrBuffer* ub, void* args);
 
 #ifdef PERFORMANCE_TESTING
-typedef void (*uxrOnPerformanceFunc) (struct uxrSession* session, uint64_t epoch_time, uint16_t length,
-                                      struct ucdrBuffer* mb, void* args);
+typedef void (*uxrOnPerformanceFunc) (struct uxrSession* session, struct ucdrBuffer* mb, void* args);
 #endif
 
 typedef struct uxrSession

--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -33,6 +33,10 @@ typedef void (*uxrOnStatusFunc) (struct uxrSession* session, uxrObjectId object_
 typedef void (*uxrOnTopicFunc) (struct uxrSession* session, uxrObjectId object_id, uint16_t request_id,
                              uxrStreamId stream_id, struct ucdrBuffer* ub, void* args);
 
+#ifdef PERFORMANCE_TESTING
+typedef void (*uxrOnEchoFunc) (struct uxrSession* session, uint16_t request_id);
+#endif
+
 typedef struct uxrSession
 {
     uxrSessionInfo info;
@@ -49,6 +53,10 @@ typedef struct uxrSession
     uxrOnTopicFunc on_topic;
     void* on_topic_args;
 
+#ifdef PERFORMANCE_TESTING
+    uxrOnEchoFunc on_echo;
+#endif
+
 } uxrSession;
 
 //==================================================================
@@ -57,6 +65,9 @@ typedef struct uxrSession
 UXRDLLAPI void uxr_init_session(uxrSession* session, struct uxrCommunication* comm, uint32_t key);
 UXRDLLAPI void uxr_set_status_callback(uxrSession* session, uxrOnStatusFunc on_status_func, void* args);
 UXRDLLAPI void uxr_set_topic_callback(uxrSession* session, uxrOnTopicFunc on_topic_func, void* args);
+#ifdef PERFORMANCE_TESTING
+UXRDLLAPI void uxr_set_echo_callback(uxrSession* session, uxrOnEchoFunc on_echo_func);
+#endif
 
 UXRDLLAPI bool uxr_create_session(uxrSession* session);
 UXRDLLAPI bool uxr_delete_session(uxrSession* session);
@@ -72,6 +83,11 @@ UXRDLLAPI bool uxr_run_session_until_timeout(uxrSession* session, int timeout);
 UXRDLLAPI bool uxr_run_session_until_confirm_delivery(uxrSession* session, int timeout);
 UXRDLLAPI bool uxr_run_session_until_all_status(uxrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
 UXRDLLAPI bool uxr_run_session_until_one_status(uxrSession* session, int timeout, const uint16_t* request_list, uint8_t* status_list, size_t list_size);
+
+#ifdef PERFORMANCE_TESTING
+UXRDLLAPI uint16_t uxr_buffer_echo(uxrSession* session, uxrStreamId stream_id);
+UXRDLLAPI bool uxr_buffer_throughput(uxrSession* session, uxrStreamId stream_id, uint8_t* buf, uint32_t size);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/uxr/client/core/session/session_info.h
+++ b/include/uxr/client/core/session/session_info.h
@@ -38,6 +38,9 @@ extern "C"
 
 #define UXR_REUSE            0x01 << 1
 #define UXR_REPLACE          0x01 << 2
+#ifdef PERFORMANCE_TESTING
+#define UXR_ECHO             0x01 << 7
+#endif
 
 #define UXR_INVALID_REQUEST_ID 0
 

--- a/src/c/core/communication/serial_protocol.c
+++ b/src/c/core/communication/serial_protocol.c
@@ -257,7 +257,7 @@ size_t uxr_read_serial_msg(uxrSerialIO* serial_io,
         }
     }
 
-    if (0 < (bytes_read[0] + bytes_read[1]))
+    if (0 < (bytes_read[0] + bytes_read[1]) || (serial_io->rb_tail != serial_io->rb_head))
     {
         /* State Machine. */
         bool exit_cond = false;

--- a/src/c/core/log/log.c
+++ b/src/c/core/log/log.c
@@ -39,8 +39,10 @@
 
 #define RESTORE_COLOR  "\x1B[0m"
 
-#define SEND_ARROW       "=>> "
-#define RECV_ARROW       "<<= "
+#define SEND_ARROW       "==> "
+#define ERROR_SEND_ARROW "!=> "
+#define RECV_ARROW       "<== "
+#define ERROR_RECV_ARROW "<=! "
 
 /* Compute output buffer size. */
 #if !defined(UXR_CONFIG_SERIAL_TRANSPORT_MTU)
@@ -93,7 +95,25 @@ void uxr_print_message(int direction, uint8_t* buffer, size_t size, const uint8_
 {
     static int64_t initial_log_time = 0;
 
-    const char* color = (direction == UXR_SEND) ? YELLOW : PURPLE;
+    const char* color;
+    switch (direction)
+    {
+        case UXR_SEND:
+            color = YELLOW;
+            break;
+        case UXR_ERROR_SEND:
+            color = RED;
+            break;
+        case UXR_RECV:
+            color = PURPLE;
+            break;
+        case UXR_ERROR_RECV:
+            color = RED;
+            break;
+        default:
+            color = WHITE;
+            break;
+    }
 
     ucdrBuffer ub;
     ucdr_init_buffer(&ub, buffer, (uint32_t)size);
@@ -237,7 +257,25 @@ void uxr_print_message(int direction, uint8_t* buffer, size_t size, const uint8_
 
 void uxr_print_serialization(int direction, const uint8_t* buffer, size_t size)
 {
-    const char* dir = (direction == UXR_SEND) ? SEND_ARROW : RECV_ARROW;
+    const char* dir;
+    switch (direction)
+    {
+        case UXR_SEND:
+            dir = SEND_ARROW;
+            break;
+        case UXR_ERROR_SEND:
+            dir = ERROR_SEND_ARROW;
+            break;
+        case UXR_RECV:
+            dir = RECV_ARROW;
+            break;
+        case UXR_ERROR_RECV:
+            dir = ERROR_RECV_ARROW;
+            break;
+        default:
+            dir = "";
+            break;
+    }
 
     printf("%s%s<< [%zu]: %s>>%s\n",
             dir,
@@ -535,8 +573,31 @@ void print_heartbeat_submessage(const char* pre, const HEARTBEAT_Payload* payloa
 
 void print_header(size_t size, int direction, uint8_t stream_id, uint16_t seq_num, const uint8_t* client_key)
 {
-    const char* arrow = (direction == UXR_SEND) ? SEND_ARROW : RECV_ARROW;
-    const char* color = (direction == UXR_SEND) ? YELLOW : PURPLE;
+    const char* arrow;
+    const char* color;
+    switch (direction)
+    {
+        case UXR_SEND:
+            arrow = SEND_ARROW;
+            color = YELLOW;
+            break;
+        case UXR_ERROR_SEND:
+            arrow = ERROR_SEND_ARROW;
+            color = RED;
+            break;
+        case UXR_RECV:
+            arrow = RECV_ARROW;
+            color = PURPLE;
+            break;
+        case UXR_ERROR_RECV:
+            arrow = ERROR_RECV_ARROW;
+            color = RED;
+            break;
+        default:
+            arrow = "";
+            color = WHITE;
+            break;
+    }
 
     char stream_representation;
     if(0 == stream_id)
@@ -561,7 +622,6 @@ void print_header(size_t size, int direction, uint8_t stream_id, uint16_t seq_nu
     {
         stream_id = (uint8_t)seq_num;
     }
-
 
     const char* client_key_str = client_key ? data_to_string(client_key, 4) : "-";
     printf("%s%s%3zu: %s(key: %s| %c:%2X |%3hu) %s", GREY_LIGHT, arrow, size, color, client_key_str, stream_representation, stream_id, seq_num_to_print, RESTORE_COLOR);

--- a/src/c/core/log/log_internal.h
+++ b/src/c/core/log/log_internal.h
@@ -24,7 +24,9 @@ extern "C"
 #include <stddef.h>
 
 #define UXR_SEND 1
+#define UXR_ERROR_SEND ~1
 #define UXR_RECV 2
+#define UXR_ERROR_RECV ~2
 
 #ifdef UXR_MESSAGE_LOGS
 #define UXR_MESSAGE_LOGS_AVAILABLE 1

--- a/src/c/core/serialization/xrce_protocol.c
+++ b/src/c/core/serialization/xrce_protocol.c
@@ -2132,7 +2132,8 @@ bool uxr_deserialize_HEARTBEAT_Payload(ucdrBuffer* buffer, HEARTBEAT_Payload* ou
 bool uxr_serialize_PERFORMANCE_Payload(ucdrBuffer* buffer, const PERFORMANCE_Payload* input)
 {
     bool ret = true;
-    ret &= ucdr_serialize_uint64_t(buffer, input->epoch_time);
+    ret &= ucdr_serialize_uint32_t(buffer, input->epoch_time_lsb);
+    ret &= ucdr_serialize_uint32_t(buffer, input->epoch_time_msb);
     ret &= ucdr_serialize_array_uint8_t(buffer, input->buf, input->len);
     return ret;
 }
@@ -2140,7 +2141,8 @@ bool uxr_serialize_PERFORMANCE_Payload(ucdrBuffer* buffer, const PERFORMANCE_Pay
 bool uxr_deserialize_PERFORMANCE_Payload(ucdrBuffer* buffer, PERFORMANCE_Payload* output)
 {
     bool ret = true;
-    ret &= ucdr_deserialize_uint64_t(buffer, &output->epoch_time);
+    ret &= ucdr_deserialize_uint32_t(buffer, &output->epoch_time_lsb);
+    ret &= ucdr_deserialize_uint32_t(buffer, &output->epoch_time_msb);
     ret &= ucdr_deserialize_array_uint8_t(buffer, output->buf, output->len);
     return ret;
 }

--- a/src/c/core/serialization/xrce_protocol.c
+++ b/src/c/core/serialization/xrce_protocol.c
@@ -2128,3 +2128,32 @@ bool uxr_deserialize_HEARTBEAT_Payload(ucdrBuffer* buffer, HEARTBEAT_Payload* ou
     return ret;
 }
 
+#ifdef PERFORMANCE_TESTING
+bool uxr_serialize_ECHO_Payload(ucdrBuffer* buffer, const ECHO_Payload* input)
+{
+    bool ret = true;
+    ret &= uxr_serialize_BaseObjectRequest(buffer, &input->base);
+    return ret;
+}
+
+bool uxr_deserialize_ECHO_Payload(ucdrBuffer* buffer, ECHO_Payload* output)
+{
+    bool ret = true;
+    ret &= uxr_deserialize_BaseObjectRequest(buffer, &output->base);
+    return ret;
+}
+
+bool uxr_serialize_THROUGHPUT_Payload(ucdrBuffer* buffer, const THROUGHPUT_Payload* input)
+{
+    bool ret = true;
+    ret &= ucdr_serialize_array_uint8_t(buffer, input->buf, input->len);
+    return ret;
+}
+
+bool uxr_deserialize_THROUGHPUT_Payload(ucdrBuffer* buffer, THROUGHPUT_Payload* output)
+{
+    bool ret = true;
+    ret &= ucdr_deserialize_array_uint8_t(buffer, output->buf, output->len);
+    return ret;
+}
+#endif

--- a/src/c/core/serialization/xrce_protocol.c
+++ b/src/c/core/serialization/xrce_protocol.c
@@ -2129,30 +2129,18 @@ bool uxr_deserialize_HEARTBEAT_Payload(ucdrBuffer* buffer, HEARTBEAT_Payload* ou
 }
 
 #ifdef PERFORMANCE_TESTING
-bool uxr_serialize_ECHO_Payload(ucdrBuffer* buffer, const ECHO_Payload* input)
+bool uxr_serialize_PERFORMANCE_Payload(ucdrBuffer* buffer, const PERFORMANCE_Payload* input)
 {
     bool ret = true;
-    ret &= uxr_serialize_BaseObjectRequest(buffer, &input->base);
-    return ret;
-}
-
-bool uxr_deserialize_ECHO_Payload(ucdrBuffer* buffer, ECHO_Payload* output)
-{
-    bool ret = true;
-    ret &= uxr_deserialize_BaseObjectRequest(buffer, &output->base);
-    return ret;
-}
-
-bool uxr_serialize_THROUGHPUT_Payload(ucdrBuffer* buffer, const THROUGHPUT_Payload* input)
-{
-    bool ret = true;
+    ret &= ucdr_serialize_uint64_t(buffer, input->epoch_time);
     ret &= ucdr_serialize_array_uint8_t(buffer, input->buf, input->len);
     return ret;
 }
 
-bool uxr_deserialize_THROUGHPUT_Payload(ucdrBuffer* buffer, THROUGHPUT_Payload* output)
+bool uxr_deserialize_PERFORMANCE_Payload(ucdrBuffer* buffer, PERFORMANCE_Payload* output)
 {
     bool ret = true;
+    ret &= ucdr_deserialize_uint64_t(buffer, &output->epoch_time);
     ret &= ucdr_deserialize_array_uint8_t(buffer, output->buf, output->len);
     return ret;
 }

--- a/src/c/core/serialization/xrce_protocol_internal.h
+++ b/src/c/core/serialization/xrce_protocol_internal.h
@@ -980,7 +980,8 @@ typedef struct HEARTBEAT_Payload
 #ifdef PERFORMANCE_TESTING
 typedef struct PERFORMANCE_Payload
 {
-    uint64_t epoch_time;
+    uint32_t epoch_time_lsb;
+    uint32_t epoch_time_msb;
     uint8_t* buf;
     uint16_t len;
 

--- a/src/c/core/serialization/xrce_protocol_internal.h
+++ b/src/c/core/serialization/xrce_protocol_internal.h
@@ -977,6 +977,21 @@ typedef struct HEARTBEAT_Payload
 
 } HEARTBEAT_Payload;
 
+#ifdef PERFORMANCE_TESTING
+typedef struct ECHO_Payload
+{
+    BaseObjectRequest base;
+
+} ECHO_Payload;
+
+typedef struct THROUGHPUT_Payload
+{
+    uint8_t* buf;
+    uint32_t len;
+
+} THROUGHPUT_Payload;
+#endif
+
 bool uxr_serialize_Time_t(ucdrBuffer* buffer, const Time_t* input);
 bool uxr_deserialize_Time_t(ucdrBuffer* buffer, Time_t* output);
 
@@ -1252,6 +1267,14 @@ bool uxr_deserialize_ACKNACK_Payload(ucdrBuffer* buffer, ACKNACK_Payload* output
 
 bool uxr_serialize_HEARTBEAT_Payload(ucdrBuffer* buffer, const HEARTBEAT_Payload* input);
 bool uxr_deserialize_HEARTBEAT_Payload(ucdrBuffer* buffer, HEARTBEAT_Payload* output);
+
+#ifdef PERFORMANCE_TESTING
+bool uxr_serialize_ECHO_Payload(ucdrBuffer* buffer, const ECHO_Payload* input);
+bool uxr_deserialize_ECHO_Payload(ucdrBuffer* buffer, ECHO_Payload* output);
+
+bool uxr_serialize_THROUGHPUT_Payload(ucdrBuffer* buffer, const THROUGHPUT_Payload* input);
+bool uxr_deserialize_THROUGHPUT_Payload(ucdrBuffer* buffer, THROUGHPUT_Payload* output);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/c/core/serialization/xrce_protocol_internal.h
+++ b/src/c/core/serialization/xrce_protocol_internal.h
@@ -978,18 +978,13 @@ typedef struct HEARTBEAT_Payload
 } HEARTBEAT_Payload;
 
 #ifdef PERFORMANCE_TESTING
-typedef struct ECHO_Payload
+typedef struct PERFORMANCE_Payload
 {
-    BaseObjectRequest base;
-
-} ECHO_Payload;
-
-typedef struct THROUGHPUT_Payload
-{
+    uint64_t epoch_time;
     uint8_t* buf;
-    uint32_t len;
+    uint16_t len;
 
-} THROUGHPUT_Payload;
+} PERFORMANCE_Payload;
 #endif
 
 bool uxr_serialize_Time_t(ucdrBuffer* buffer, const Time_t* input);
@@ -1269,11 +1264,8 @@ bool uxr_serialize_HEARTBEAT_Payload(ucdrBuffer* buffer, const HEARTBEAT_Payload
 bool uxr_deserialize_HEARTBEAT_Payload(ucdrBuffer* buffer, HEARTBEAT_Payload* output);
 
 #ifdef PERFORMANCE_TESTING
-bool uxr_serialize_ECHO_Payload(ucdrBuffer* buffer, const ECHO_Payload* input);
-bool uxr_deserialize_ECHO_Payload(ucdrBuffer* buffer, ECHO_Payload* output);
-
-bool uxr_serialize_THROUGHPUT_Payload(ucdrBuffer* buffer, const THROUGHPUT_Payload* input);
-bool uxr_deserialize_THROUGHPUT_Payload(ucdrBuffer* buffer, THROUGHPUT_Payload* output);
+bool uxr_serialize_PERFORMANCE_Payload(ucdrBuffer* buffer, const PERFORMANCE_Payload* input);
+bool uxr_deserialize_PERFORMANCE_Payload(ucdrBuffer* buffer, PERFORMANCE_Payload* input);
 #endif
 
 #ifdef __cplusplus

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -266,7 +266,7 @@ bool uxr_buffer_throughput(uxrSession* session, uxrStreamId stream_id, uint8_t* 
     payload.len = len;
 
     ucdrBuffer mb;
-    if (uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)len, &mb))
+    if (uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(len + SUBHEADER_SIZE), &mb))
     {
         (void) uxr_buffer_submessage_header(&mb, SUBMESSAGE_ID_THROUGHPUT, (uint16_t)len, 0);
         (void) uxr_serialize_THROUGHPUT_Payload(&mb, &payload);

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -254,7 +254,8 @@ bool uxr_buffer_performance(uxrSession *session,
     payload.buf = buf;
     payload.len = len;
     ucdrBuffer mb;
-    if (uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(SUBHEADER_SIZE + 8 + len), &mb))
+    const uint16_t size_to_write = (uint16_t)(SUBHEADER_SIZE + sizeof(epoch_time) + len);
+    if (uxr_prepare_stream_to_write(&session->streams, stream_id, size_to_write, &mb))
     {
         uint8_t flags = (echo) ? UXR_ECHO : 0;
         (void) uxr_buffer_submessage_header(&mb, SUBMESSAGE_ID_PERFORMANCE, (uint16_t)(8 + len), flags);
@@ -598,8 +599,12 @@ void read_submessage_performance(uxrSession* session, ucdrBuffer* submessage, ui
     ucdr_deserialize_uint64_t(submessage, &epoch_time);
 
     ucdrBuffer mb_performance;
-    ucdr_init_buffer(&mb_performance, submessage->iterator, (uint16_t)(length - 4));
-    session->on_performance(session, epoch_time, (uint16_t)(length - 4), &mb_performance, session->on_performance_args);
+    ucdr_init_buffer(&mb_performance, submessage->iterator, (uint16_t)(length - sizeof(epoch_time)));
+    session->on_performance(session,
+                            epoch_time,
+                            (uint16_t)(length - sizeof(epoch_time)),
+                            &mb_performance,
+                            session->on_performance_args);
 }
 #endif
 

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -25,7 +25,7 @@ static bool listen_message_reliably(uxrSession* session, int poll_ms);
 
 static bool wait_session_status(uxrSession* session, uint8_t* buffer, size_t length, size_t attempts);
 
-static void send_message(const uxrSession* session, uint8_t* buffer, size_t length);
+static bool send_message(const uxrSession* session, uint8_t* buffer, size_t length);
 static bool recv_message(const uxrSession* session, uint8_t** buffer, size_t* length, int poll_ms);
 
 static void write_submessage_heartbeat(const uxrSession* session, uxrStreamId stream);
@@ -331,10 +331,14 @@ bool wait_session_status(uxrSession* session, uint8_t* buffer, size_t length, si
     return session->info.last_requested_status != UXR_STATUS_NONE;
 }
 
-inline void send_message(const uxrSession* session, uint8_t* buffer, size_t length)
+inline bool send_message(const uxrSession* session, uint8_t* buffer, size_t length)
 {
-    (void) session->comm->send_msg(session->comm->instance, buffer, length);
-    UXR_DEBUG_PRINT_MESSAGE(UXR_SEND, buffer, length, session->info.key);
+    bool sent = session->comm->send_msg(session->comm->instance, buffer, length);
+    if (sent)
+    {
+        UXR_DEBUG_PRINT_MESSAGE(UXR_SEND, buffer, length, session->info.key);
+    }
+    return sent;
 }
 
 inline bool recv_message(const uxrSession* session, uint8_t**buffer, size_t* length, int poll_ms)

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -254,10 +254,10 @@ bool uxr_buffer_performance(uxrSession *session,
     payload.buf = buf;
     payload.len = len;
     ucdrBuffer mb;
-    if (uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(SUBHEADER_SIZE + 4 + len), &mb))
+    if (uxr_prepare_stream_to_write(&session->streams, stream_id, (uint16_t)(SUBHEADER_SIZE + 8 + len), &mb))
     {
         uint8_t flags = (echo) ? UXR_ECHO : 0;
-        (void) uxr_buffer_submessage_header(&mb, SUBMESSAGE_ID_PERFORMANCE, (uint16_t)(4 + len), flags);
+        (void) uxr_buffer_submessage_header(&mb, SUBMESSAGE_ID_PERFORMANCE, (uint16_t)(8 + len), flags);
         (void) uxr_serialize_PERFORMANCE_Payload(&mb, &payload);
         rv = true;
     }

--- a/src/c/core/session/submessage_internal.h
+++ b/src/c/core/session/submessage_internal.h
@@ -47,8 +47,7 @@ typedef enum SubmessageId
     SUBMESSAGE_ID_FRAGMENT      = 13
 #ifdef PERFORMANCE_TESTING
     ,
-    SUBMESSAGE_ID_ECHO          = 14,
-    SUBMESSAGE_ID_THROUGHPUT    = 15
+    SUBMESSAGE_ID_PERFORMANCE   = 14
 #endif
 
 } SubmessageId;

--- a/src/c/core/session/submessage_internal.h
+++ b/src/c/core/session/submessage_internal.h
@@ -45,6 +45,11 @@ typedef enum SubmessageId
     SUBMESSAGE_ID_HEARTBEAT     = 11,
     SUBMESSAGE_ID_RESET         = 12,
     SUBMESSAGE_ID_FRAGMENT      = 13
+#ifdef PERFORMANCE_TESTING
+    ,
+    SUBMESSAGE_ID_ECHO          = 14,
+    SUBMESSAGE_ID_THROUGHPUT    = 15
+#endif
 
 } SubmessageId;
 

--- a/src/c/profile/transport/serial/serial_transport_linux.c
+++ b/src/c/profile/transport/serial/serial_transport_linux.c
@@ -18,16 +18,7 @@ bool uxr_init_serial_platform(struct uxrSerialPlatform* platform, int fd, uint8_
 
 bool uxr_close_serial_platform(struct uxrSerialPlatform* platform)
 {
-    bool rv = false;
-    if (-1 == platform->poll_fd.fd)
-    {
-        rv = true;
-    }
-    else
-    {
-        rv = (0 == close(platform->poll_fd.fd));
-    }
-    return rv;
+    return (-1 == platform->poll_fd.fd) ? true : (0 == close(platform->poll_fd.fd));
 }
 
 size_t uxr_write_serial_data_platform(uxrSerialPlatform* platform, uint8_t* buf, size_t len, uint8_t* errcode)

--- a/src/c/profile/transport/serial/serial_transport_linux.c
+++ b/src/c/profile/transport/serial/serial_transport_linux.c
@@ -18,7 +18,16 @@ bool uxr_init_serial_platform(struct uxrSerialPlatform* platform, int fd, uint8_
 
 bool uxr_close_serial_platform(struct uxrSerialPlatform* platform)
 {
-    return (0 == close(platform->poll_fd.fd));
+    bool rv = false;
+    if (-1 == platform->poll_fd.fd)
+    {
+        rv = true;
+    }
+    else
+    {
+        rv = (0 == close(platform->poll_fd.fd));
+    }
+    return rv;
 }
 
 size_t uxr_write_serial_data_platform(uxrSerialPlatform* platform, uint8_t* buf, size_t len, uint8_t* errcode)

--- a/src/c/profile/transport/tcp/tcp_transport.c
+++ b/src/c/profile/transport/tcp/tcp_transport.c
@@ -39,7 +39,7 @@ bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
         if (0 < send_rv)
         {
             bytes_sent = (size_t)(bytes_sent + send_rv);
-            size_sent = (bytes_sent == 2);
+            size_sent = (sizeof(msg_size_buf) == bytes_sent);
         }
         else
         {

--- a/src/c/profile/transport/tcp/tcp_transport.c
+++ b/src/c/profile/transport/tcp/tcp_transport.c
@@ -49,6 +49,7 @@ bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
                 break;
             }
         }
+        ++n_attemps;
     }
     while (!size_sent && n_attemps < UXR_MAX_WRITE_TCP_ATTEMPS);
 
@@ -56,6 +57,7 @@ bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
     bool payload_sent = false;
     if (size_sent)
     {
+        n_attemps = 0;
         bytes_sent = 0;
         do
         {
@@ -77,6 +79,7 @@ bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
                     break;
                 }
             }
+            ++n_attemps;
         }
         while (!payload_sent && n_attemps < UXR_MAX_WRITE_TCP_ATTEMPS);
     }

--- a/src/c/profile/transport/tcp/tcp_transport.c
+++ b/src/c/profile/transport/tcp/tcp_transport.c
@@ -1,6 +1,8 @@
 #include "tcp_transport_internal.h"
 #include <uxr/client/util/time.h>
 
+#define UXR_MAX_WRITE_TCP_ATTEMPS 16
+
 /*******************************************************************************
  * Static members.
  *******************************************************************************/
@@ -19,58 +21,73 @@ static size_t read_tcp_data(uxrTCPTransport* transport, int timeout);
  *******************************************************************************/
 bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
 {
-    bool rv = true;
+    bool rv = false;
     uxrTCPTransport* transport = (uxrTCPTransport*)instance;
-    size_t bytes_sent = 0;
-    size_t send_rv = 0;
     uint8_t msg_size_buf[2];
 
-    /* Send message size. */
     msg_size_buf[0] = (uint8_t)(0x00FF & len);
     msg_size_buf[1] = (uint8_t)((0xFF00 & len) >> 8);
+    uint8_t n_attemps = 0;
+    size_t bytes_sent = 0;
+
+    /* Send message size. */
+    bool size_sent = false;
     do
     {
         uint8_t errcode;
-        send_rv = uxr_write_tcp_data_platform(transport->platform, msg_size_buf, 2, &errcode);
+        size_t send_rv = uxr_write_tcp_data_platform(transport->platform, msg_size_buf, 2, &errcode);
         if (0 < send_rv)
         {
             bytes_sent = (size_t)(bytes_sent + send_rv);
+            size_sent = (bytes_sent == 2);
         }
         else
         {
             if (0 < errcode)
             {
-                uxr_disconnect_tcp_platform(transport->platform);
                 error_code = errcode;
-                rv = false;
+                break;
             }
         }
     }
-    while (rv && bytes_sent != 2);
+    while (!size_sent && n_attemps < UXR_MAX_WRITE_TCP_ATTEMPS);
 
     /* Send message payload. */
-    if (rv)
+    bool payload_sent = false;
+    if (size_sent)
     {
         bytes_sent = 0;
         do
         {
             uint8_t errcode;
-            send_rv = uxr_write_tcp_data_platform(transport->platform, buf + bytes_sent, len - bytes_sent, &errcode);
+            size_t send_rv = uxr_write_tcp_data_platform(transport->platform, 
+                                                         buf + bytes_sent, 
+                                                         len - bytes_sent, 
+                                                         &errcode);
             if (0 < send_rv)
             {
                 bytes_sent = (size_t)(bytes_sent + send_rv);
+                payload_sent = (bytes_sent == len);
             }
             else
             {
                 if (0 < errcode)
                 {
-                    uxr_disconnect_tcp_platform(transport->platform);
                     error_code = errcode;
-                    rv = false;
+                    break;
                 }
             }
         }
-        while (rv && (bytes_sent != len));
+        while (!payload_sent && n_attemps < UXR_MAX_WRITE_TCP_ATTEMPS);
+    }
+
+    if (size_sent && payload_sent)
+    {
+        rv = true;
+    }
+    else
+    {
+        uxr_disconnect_tcp_platform(transport->platform);
     }
 
     return rv;

--- a/src/c/profile/transport/tcp/tcp_transport.c
+++ b/src/c/profile/transport/tcp/tcp_transport.c
@@ -81,7 +81,7 @@ bool send_tcp_msg(void* instance, const uint8_t* buf, size_t len)
         while (!payload_sent && n_attemps < UXR_MAX_WRITE_TCP_ATTEMPS);
     }
 
-    if (size_sent && payload_sent)
+    if (payload_sent)
     {
         rv = true;
     }

--- a/src/c/profile/transport/tcp/tcp_transport_linux.c
+++ b/src/c/profile/transport/tcp/tcp_transport_linux.c
@@ -43,16 +43,7 @@ bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint
 
 bool uxr_close_tcp_platform(struct uxrTCPPlatform* platform)
 {
-    bool rv = false;
-    if (-1 == platform->poll_fd.fd)
-    {
-        rv = true;
-    }
-    else
-    {
-        rv = (0 == close(platform->poll_fd.fd));
-    }
-    return rv;
+    return (-1 == platform->poll_fd.fd) ? true : (0 == close(platform->poll_fd.fd));
 }
 
 size_t uxr_write_tcp_data_platform(struct uxrTCPPlatform* platform,

--- a/src/c/profile/transport/tcp/tcp_transport_linux.c
+++ b/src/c/profile/transport/tcp/tcp_transport_linux.c
@@ -43,7 +43,16 @@ bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint
 
 bool uxr_close_tcp_platform(struct uxrTCPPlatform* platform)
 {
-    return (0 == close(platform->poll_fd.fd));
+    bool rv = false;
+    if (-1 == platform->poll_fd.fd)
+    {
+        rv = true;
+    }
+    else
+    {
+        rv = (0 == close(platform->poll_fd.fd));
+    }
+    return rv;
 }
 
 size_t uxr_write_tcp_data_platform(struct uxrTCPPlatform* platform,

--- a/src/c/profile/transport/tcp/tcp_transport_linux.c
+++ b/src/c/profile/transport/tcp/tcp_transport_linux.c
@@ -5,6 +5,12 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <signal.h>
+
+static void sigpipe_handler(int fd)
+{
+    (void)fd;
+}
 
 bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint16_t port)
 {
@@ -14,6 +20,8 @@ bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint
     platform->poll_fd.fd = socket(PF_INET, SOCK_STREAM, 0);
     if (-1 != platform->poll_fd.fd)
     {
+        signal(SIGPIPE, sigpipe_handler);
+
         /* Remote IP setup. */
         struct sockaddr_in temp_addr;
         temp_addr.sin_family = AF_INET;

--- a/src/c/profile/transport/tcp/tcp_transport_windows.c
+++ b/src/c/profile/transport/tcp/tcp_transport_windows.c
@@ -39,15 +39,7 @@ bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint
 
 bool uxr_close_tcp_platform(struct uxrTCPPlatform* platform)
 {
-    bool rv = false;
-    if (INVALID_SOCKET == platform->poll_fd.fd)
-    {
-        rv = true;
-    }
-    else
-    {
-        rv = (0 == closesocket(platform->poll_fd.fd));
-    }
+    bool rv = (INVALID_SOCKET == platform->poll_fd.fd) ? true : (0 == closesocket(platform->poll_fd.fd));
     return (0 == WSACleanup()) && rv;
 }
 

--- a/src/c/profile/transport/tcp/tcp_transport_windows.c
+++ b/src/c/profile/transport/tcp/tcp_transport_windows.c
@@ -40,11 +40,15 @@ bool uxr_init_tcp_platform(struct uxrTCPPlatform* platform, const char* ip, uint
 bool uxr_close_tcp_platform(struct uxrTCPPlatform* platform)
 {
     bool rv = false;
-    if (0 == closesocket(platform->poll_fd.fd))
+    if (INVALID_SOCKET == platform->poll_fd.fd)
     {
-        rv = (0 == WSACleanup());
+        rv = true;
     }
-    return rv;
+    else
+    {
+        rv = (0 == closesocket(platform->poll_fd.fd));
+    }
+    return (0 == WSACleanup()) && rv;
 }
 
 size_t uxr_write_tcp_data_platform(struct uxrTCPPlatform* platform,

--- a/src/c/profile/transport/udp/udp_transport_linux.c
+++ b/src/c/profile/transport/udp/udp_transport_linux.c
@@ -33,7 +33,16 @@ bool uxr_init_udp_platform(uxrUDPPlatform* platform, const char* ip, uint16_t po
 
 bool uxr_close_udp_platform(uxrUDPPlatform* platform)
 {
-    return (0 == close(platform->poll_fd.fd));
+    bool rv = false;
+    if (-1 == platform->poll_fd.fd)
+    {
+        rv = true;
+    }
+    else
+    {
+        rv = (0 == close(platform->poll_fd.fd));
+    }
+    return rv;
 }
 
 size_t uxr_write_udp_data_platform(uxrUDPPlatform* platform, const uint8_t* buf, size_t len, uint8_t* errcode)

--- a/src/c/profile/transport/udp/udp_transport_linux.c
+++ b/src/c/profile/transport/udp/udp_transport_linux.c
@@ -33,16 +33,7 @@ bool uxr_init_udp_platform(uxrUDPPlatform* platform, const char* ip, uint16_t po
 
 bool uxr_close_udp_platform(uxrUDPPlatform* platform)
 {
-    bool rv = false;
-    if (-1 == platform->poll_fd.fd)
-    {
-        rv = true;
-    }
-    else
-    {
-        rv = (0 == close(platform->poll_fd.fd));
-    }
-    return rv;
+    return (-1 == platform->poll_fd.fd) ? true : (0 == close(platform->poll_fd.fd));
 }
 
 size_t uxr_write_udp_data_platform(uxrUDPPlatform* platform, const uint8_t* buf, size_t len, uint8_t* errcode)

--- a/src/c/profile/transport/udp/udp_transport_windows.c
+++ b/src/c/profile/transport/udp/udp_transport_windows.c
@@ -37,11 +37,15 @@ bool uxr_init_udp_platform(uxrUDPPlatform* platform, const char* ip, uint16_t po
 bool uxr_close_udp_platform(uxrUDPPlatform* platform)
 {
     bool rv = false;
-    if (0 == closesocket(platform->poll_fd.fd))
+    if (INVALID_SOCKET == platform->poll_fd.fd)
     {
-        rv = (0 == WSACleanup());
+        rv = true;
     }
-    return rv;
+    else
+    {
+        rv = (0 == closesocket(platform->poll_fd.fd));
+    }
+    return (0 == WSACleanup()) && rv;
 }
 
 size_t uxr_write_udp_data_platform(uxrUDPPlatform* platform, const uint8_t* buf, size_t len, uint8_t* errcode)

--- a/src/c/profile/transport/udp/udp_transport_windows.c
+++ b/src/c/profile/transport/udp/udp_transport_windows.c
@@ -36,15 +36,7 @@ bool uxr_init_udp_platform(uxrUDPPlatform* platform, const char* ip, uint16_t po
 
 bool uxr_close_udp_platform(uxrUDPPlatform* platform)
 {
-    bool rv = false;
-    if (INVALID_SOCKET == platform->poll_fd.fd)
-    {
-        rv = true;
-    }
-    else
-    {
-        rv = (0 == closesocket(platform->poll_fd.fd));
-    }
+    bool rv = (INVALID_SOCKET == platform->poll_fd.fd) ? true : (0 == closesocket(platform->poll_fd.fd));
     return (0 == WSACleanup()) && rv;
 }
 


### PR DESCRIPTION
This pull request adds support for the performance test. It has the following changes:
* The CMakeLists.txt has been modified with a new flag for activating the performance test.
* A new submessage (`PERFORMANCE`) has been introduced with a new callback to manage it.
The payload of this new submessage is composed by the `epoch_time` (64 bit), following by an array of octets with variable length. This submessage has two main purposes: 1) send raw data to the Agent in order to test the throughput, and 2) send echoes message for measuring the latency between the Agent and the Client.