### PR TITLE
Hotfix example pubsub index [5406]

### DIFF
--- a/examples/PublishHelloWorld/main.c
+++ b/examples/PublishHelloWorld/main.c
@@ -109,18 +109,15 @@ int main(int args, char** argv)
     uint32_t count = 0;
     while(connected && count < max_topics)
     {
-        HelloWorld topic = {count++, "Hello DDS world!"};
+        HelloWorld topic = {++count, "Hello DDS world!"};
 
         ucdrBuffer mb;
         uint32_t topic_size = HelloWorld_size_of_topic(&topic, 0);
         uxr_prepare_output_stream(&session, reliable_out, datawriter_id, &mb, topic_size);
         HelloWorld_serialize_topic(&mb, &topic);
 
+        printf("Send topic: %s, id: %i\n", topic.message, topic.index);
         connected = uxr_run_session_time(&session, 1000);
-        if(connected)
-        {
-            printf("Sent topic: %s, id: %i\n", topic.message, topic.index);
-        }
     }
 
     // Delete resources


### PR DESCRIPTION
The publisher writes the sent topic message 1 second after the subscriber does.
Fixed. Also, the id will start at 1.