### PR TITLE
Improved on uxr_close_tcp_platform() to avoid potentially losing bytes in flight.

### DIFF
--- a/src/c/profile/transport/ip/tcp/tcp_transport_posix.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_posix.c
@@ -74,7 +74,22 @@ bool uxr_init_tcp_platform(
 bool uxr_close_tcp_platform(
         struct uxrTCPPlatform* platform)
 {
-    return (-1 == platform->poll_fd.fd) ? true : (0 == close(platform->poll_fd.fd));
+    bool rv = true;
+
+    if (-1 != platform->poll_fd.fd)
+    {
+        /* Synchronize the stream with the agent, to avoid losing bytes currently in flight.  */
+        shutdown(platform->poll_fd.fd, SHUT_WR);
+        int poll_rv = poll(&platform->poll_fd, 1, 10000);
+        if (0 < poll_rv)
+        {
+            char dummy;
+            while (recv(platform->poll_fd.fd, &dummy, sizeof(dummy), 0) > 0) {};
+        }
+
+        rv = (0 == close(platform->poll_fd.fd));
+    }
+    return rv;
 }
 
 size_t uxr_write_tcp_data_platform(

--- a/src/c/profile/transport/ip/tcp/tcp_transport_windows.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_windows.c
@@ -67,8 +67,24 @@ bool uxr_init_tcp_platform(
 
 bool uxr_close_tcp_platform(struct uxrTCPPlatform* platform)
 {
-    bool rv = (INVALID_SOCKET == platform->poll_fd.fd) ? true : (0 == closesocket(platform->poll_fd.fd));
-    return (0 == WSACleanup()) && rv;
+    bool rv = true;
+
+    if (INVALID_SOCKET != platform->poll_fd.fd)
+    {
+        /* Synchronize the stream with the agent, to avoid losing bytes currently in flight.  */
+        shutdown(platform->poll_fd.fd, SD_SEND);
+        int poll_rv = WSAPoll(&platform->poll_fd, 1, 10000);
+        if (0 < poll_rv)
+        {
+            char dummy;
+            while (recv(platform->poll_fd.fd, &dummy, sizeof(dummy), 0) > 0) {};
+        }
+        if (0 == closesocket(platform->poll_fd.fd))
+        {
+            rv = (0 == WSACleanup());
+        }
+    }
+    return rv;
 }
 
 size_t uxr_write_tcp_data_platform(struct uxrTCPPlatform* platform,


### PR DESCRIPTION
This is similar to the third point mentioned in my new PR within the Agent repository.

This revolves around the fact that send() does not guarantee that the receiver will receive all data. By waiting for the other side (the agent in this case) to also close the connection, we can be sure that all data that should have been received, was received.
This also solves another problem: under such a condition, calling close() on the socket() will result in the remote end sending a TCP RST in response to the FIN-ACK.