### PR TITLE
Added uxr_run_session_timeout

### DIFF
--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -271,6 +271,20 @@ UXRDLLAPI bool uxr_run_session_time(
  *         This function involves the following actions:
  *          1. flashing all the output streams sending the data through the transport,
  *          2. listening messages from the Agent calling the associated callback (topic and status).
+ *        The aforementioned actions will be performed in a loop until the `timeout` is exceeded.
+ * @param session   A uxrSession structure previously initialized.
+ * @param timeout   The waiting time in milliseconds.
+ * @return  `true` in case of the Agent confirms the reception of all the output messages. `false` in other case.
+ */
+UXRDLLAPI bool uxr_run_session_timeout(
+        uxrSession* session,
+        int timeout);
+
+/**
+ * @brief  Keeps communication between the Client and the Agent.
+ *         This function involves the following actions:
+ *          1. flashing all the output streams sending the data through the transport,
+ *          2. listening messages from the Agent calling the associated callback (topic and status).
  *        The aforementioned actions will be performed in a loop until a message is received
  *        or the `timeout` is exceeded.
  * @param session   A uxrSession structure previously initialized.

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -189,12 +189,14 @@ bool uxr_run_session_time(uxrSession* session, int timeout_ms)
 bool uxr_run_session_timeout(uxrSession* session, int timeout_ms)
 {
     int64_t start_timestamp = uxr_millis();
+    int remaining_time = timeout_ms;
 
     uxr_flash_output_streams(session);
 
-    while(uxr_millis() - start_timestamp < timeout_ms)
+    while(remaining_time > 0)
     {
-        listen_message_reliably(session, timeout_ms);
+        listen_message_reliably(session, remaining_time);
+        remaining_time = timeout_ms - (uxr_millis() - start_timestamp);
     }
     return uxr_output_streams_confirmed(&session->streams);
 }

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -186,6 +186,19 @@ bool uxr_run_session_time(uxrSession* session, int timeout_ms)
     return uxr_output_streams_confirmed(&session->streams);
 }
 
+bool uxr_run_session_timeout(uxrSession* session, int timeout_ms)
+{
+    int64_t start_timestamp = uxr_millis();
+
+    uxr_flash_output_streams(session);
+
+    while(uxr_millis() - start_timestamp < timeout_ms)
+    {
+        listen_message_reliably(session, timeout_ms);
+    }
+    return uxr_output_streams_confirmed(&session->streams);
+}
+
 bool uxr_run_session_until_timeout(uxrSession* session, int timeout_ms)
 {
     uxr_flash_output_streams(session);

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -196,7 +196,7 @@ bool uxr_run_session_timeout(uxrSession* session, int timeout_ms)
     while(remaining_time > 0)
     {
         listen_message_reliably(session, remaining_time);
-        remaining_time = timeout_ms - (uxr_millis() - start_timestamp);
+        remaining_time = timeout_ms - (int)(uxr_millis() - start_timestamp);
     }
     return uxr_output_streams_confirmed(&session->streams);
 }


### PR DESCRIPTION
This PR adds uxr_run_session_timeout function which:
   - flash output buffers
   - listen messages during specified time
   - return whether the output streams are confirmed