### PR TITLE
Fix fragmentation

### DIFF
--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -99,8 +99,18 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
         uint16_t available_block_size = (uint16_t)(buffer_capacity - (uint16_t)(stream->offset + SUBHEADER_SIZE));
         uint16_t first_fragment_size = (uint16_t)(buffer_capacity - (uint16_t)(buffer_size + SUBHEADER_SIZE));
         uint16_t remaining_size = (uint16_t)(length - first_fragment_size);
-        uint16_t last_fragment_size = (remaining_size % available_block_size);
-        uint16_t necessary_blocks = (uint16_t)((0 < first_fragment_size) + (remaining_size / available_block_size) + (0 < last_fragment_size));
+        uint16_t last_fragment_size;
+        uint16_t necessary_blocks;
+        if (0 == (remaining_size % available_block_size))
+        {
+            last_fragment_size = available_block_size;
+            necessary_blocks = (uint16_t)((0 < first_fragment_size) + (remaining_size / available_block_size));
+        }
+        else
+        {
+            last_fragment_size = remaining_size % available_block_size;
+            necessary_blocks = (uint16_t)((0 < first_fragment_size) + (remaining_size / available_block_size) + 1);
+        }
 
         available_to_write = necessary_blocks <= remaining_blocks;
         if(available_to_write)

--- a/test/unitary/session/streams/OutputReliableStream.cpp
+++ b/test/unitary/session/streams/OutputReliableStream.cpp
@@ -16,6 +16,7 @@ extern "C"
 #define SUBMESSAGE_SIZE       size_t(8)
 #define MAX_SUBMESSAGE_SIZE   (MAX_MESSAGE_SIZE - OFFSET)
 #define FRAGMENT_OFFSET       size_t(4)
+#define MAX_FRAGMENT_SIZE     (MAX_MESSAGE_SIZE - OFFSET - FRAGMENT_OFFSET)
 
 bool operator == (const uxrOutputReliableStream& stream1, const uxrOutputReliableStream& stream2)
 {
@@ -195,6 +196,15 @@ TEST_F(OutputReliableStreamTest, WriteFragmentMessage)
     EXPECT_TRUE(ucdr_serialize_array_uint8_t(&ub, message_to_write, message_length));
     EXPECT_EQ(slot_2 + OFFSET + FRAGMENT_OFFSET + SUBMESSAGE_SIZE, ub.iterator);
     EXPECT_EQ(slot_2 + OFFSET + FRAGMENT_OFFSET + SUBMESSAGE_SIZE, ub.final);
+}
+
+TEST_F(OutputReliableStreamTest, WriteMaxSubmessageSize)
+{
+    ucdrBuffer ub;
+    bool available_to_write = uxr_prepare_reliable_buffer_to_write(&stream, 2 * MAX_FRAGMENT_SIZE, &ub);
+    ASSERT_TRUE(available_to_write);
+    EXPECT_EQ(MAX_MESSAGE_SIZE, uxr_get_reliable_buffer_size(&stream.base, 0));
+    EXPECT_EQ(MAX_MESSAGE_SIZE, uxr_get_reliable_buffer_size(&stream.base, 1));
 }
 
 TEST_F(OutputReliableStreamTest, WriteMessagesUntilFullBuffer)


### PR DESCRIPTION
This PR fixes fragmentation bug due to a bad message splitting with `last_fragment_size == available_block_size`.

Before merge:
- [ ] Add a regression test (see #147).