### PR TITLE
Hotfix request/reply

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND _deps "microcdr\;${_microcdr_version}")
 ###############################################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 if(NOT UCLIENT_SUPERBUILD)
-    project(microxrcedds_client VERSION "1.2.3" LANGUAGES C)
+    project(microxrcedds_client VERSION "1.2.4" LANGUAGES C)
 else()
     project(uclient_superbuild NONE)
     include(${PROJECT_SOURCE_DIR}/cmake/SuperBuild.cmake)

--- a/src/c/core/session/read_access.c
+++ b/src/c/core/session/read_access.c
@@ -183,7 +183,7 @@ inline void read_format_data(
 
                 if (uxr_deserialize_SampleIdentity(&temp_buffer, &sample_id))
                 {
-                    length = (uint16_t)(length - (temp_buffer.offset - offset));
+                    uint16_t request_length = (uint16_t)(length - (temp_buffer.offset - offset));
                     ucdr_init_buffer(&temp_buffer, temp_buffer.iterator, (size_t)(temp_buffer.final - temp_buffer.iterator));
                     ucdr_set_on_full_buffer_callback(&temp_buffer, ub->on_full_buffer, ub->args);
 
@@ -193,7 +193,7 @@ inline void read_format_data(
                         request_id,
                         &sample_id,
                         &temp_buffer,
-                        (size_t)length,
+                        (size_t)request_length,
                         session->on_request_args);
                 }
             }
@@ -208,7 +208,7 @@ inline void read_format_data(
 
                 if (uxr_deserialize_BaseObjectRequest(&temp_buffer, &request))
                 {
-                    length = (uint16_t)(length - (temp_buffer.offset - offset));
+                    uint16_t reply_length = (uint16_t)(length - (temp_buffer.offset - offset));
                     ucdr_init_buffer(&temp_buffer, temp_buffer.iterator, (size_t)(temp_buffer.final - temp_buffer.iterator));
                     ucdr_set_on_full_buffer_callback(&temp_buffer, ub->on_full_buffer, ub->args);
 
@@ -218,7 +218,7 @@ inline void read_format_data(
                         request_id,
                         (uint16_t)((request.request_id.data[0] << 8) + request.request_id.data[1]),
                         &temp_buffer,
-                        (size_t)length,
+                        (size_t)reply_length,
                         session->on_reply_args);
                 }
             }

--- a/src/c/core/session/read_access.c
+++ b/src/c/core/session/read_access.c
@@ -17,7 +17,7 @@ extern void read_submessage_format(
 static void read_format_data(
         uxrSession* session,
         ucdrBuffer* payload,
-        uint16_t length,
+        const uint16_t length,
         uxrStreamId stream_id,
         uxrObjectId object_id,
         uint16_t request_id);
@@ -148,13 +148,11 @@ void read_submessage_format(
 inline void read_format_data(
         uxrSession* session,
         ucdrBuffer* ub,
-        uint16_t length,
+        const uint16_t length,
         uxrStreamId stream_id,
         uxrObjectId object_id,
         uint16_t request_id)
 {
-    (void) length;
-
     ucdrBuffer temp_buffer;
     ucdr_init_buffer(&temp_buffer, ub->iterator, (size_t)(ub->final - ub->iterator));
     ucdr_set_on_full_buffer_callback(&temp_buffer, ub->on_full_buffer, ub->args);

--- a/test/unitary/CMakeLists.txt
+++ b/test/unitary/CMakeLists.txt
@@ -50,8 +50,9 @@ unitary_test(InputReliableStream    session/streams/InputReliableStream.cpp)
 unitary_test(OutputReliableStream   session/streams/OutputReliableStream.cpp)
 unitary_test(StreamStorage          session/streams/StreamStorage.cpp)
 
-unitary_test(ObjectId    session/ObjectId.cpp)
-unitary_test(Submessage  session/Submessage.cpp)
-unitary_test(SessionInfo session/SessionInfo.cpp)
-unitary_test(Session     session/Session.cpp)
+unitary_test(ObjectId           session/ObjectId.cpp)
+unitary_test(Submessage         session/Submessage.cpp)
+unitary_test(SessionInfo        session/SessionInfo.cpp)
+unitary_test(Session            session/Session.cpp)
+unitary_test(WriteReadAccess    session/WriteReadAccess.cpp)
 

--- a/test/unitary/session/WriteReadAccess.cpp
+++ b/test/unitary/session/WriteReadAccess.cpp
@@ -1,0 +1,144 @@
+extern "C"
+{
+#include <c/core/serialization/xrce_types.c>
+#include <c/core/serialization/xrce_header.c>
+#include <c/core/serialization/xrce_subheader.c>
+
+#include <c/core/session/stream/seq_num.c>
+#include <c/core/session/stream/stream_id.c>
+#include <c/core/session/stream/stream_storage.c>
+#include <c/core/session/stream/input_best_effort_stream.c>
+#include <c/core/session/stream/output_best_effort_stream.c>
+#include <c/core/session/stream/input_reliable_stream.c>
+#include <c/core/session/stream/output_reliable_stream.c>
+
+#include <c/core/session/object_id.c>
+#include <c/core/session/submessage.c>
+#include <c/core/session/session_info.c>
+#include <c/core/session/read_access.c>
+#include <c/core/session/write_access.c>
+#include <c/core/session/session.c>
+
+#include <c/util/time.c>
+}
+
+#include <gtest/gtest.h>
+
+#define MTU     64
+#define HISTORY 4
+#define TOPIC_FITTED_SIZE   (MTU - (MIN_HEADER_SIZE + SUBHEADER_SIZE + WRITE_DATA_PAYLOAD_SIZE))
+#define REQUEST_FITTED_SIZE TOPIC_FITTED_SIZE
+#define REPLY_FITTED_SIZE   (MTU - (MIN_HEADER_SIZE + SUBHEADER_SIZE + WRITE_DATA_PAYLOAD_SIZE) - sizeof(SampleIdentity))
+
+class WriteReadAccessTest : public testing::Test
+{
+public:
+    WriteReadAccessTest()
+        : session_{}
+        , data_writer_id_{uxr_object_id(0, UXR_DATAWRITER_ID)}
+        , data_reader_id_{uxr_object_id(0, UXR_DATAREADER_ID)}
+        , requester_id_{uxr_object_id(0, UXR_REQUESTER_ID)}
+        , replier_id_{uxr_object_id(0, UXR_REPLIER_ID)}
+    {
+        uxr_init_session(&session_, NULL, 0xAAAABBBB);
+        uxr_create_output_best_effort_stream(&session_, output_best_effort_buffer, MTU);
+    }
+
+protected:
+    uxrSession session_;
+    uxrObjectId data_writer_id_;
+    uxrObjectId data_reader_id_;
+    uxrObjectId requester_id_;
+    uxrObjectId replier_id_;
+
+private:
+    uint8_t output_best_effort_buffer[MTU];
+};
+
+TEST_F(WriteReadAccessTest, PrepareStreamToWriteSubmessage)
+{
+    ucdrBuffer ub;
+    uxrStreamId stream_id;
+    uint16_t data_length;
+
+    // stream_id:   no valid
+    // data_length: fitted
+    // extected:    false
+    stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(TOPIC_FITTED_SIZE);
+    ASSERT_FALSE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
+
+    // stream_id:   valid
+    // data_length: no fitted
+    // extected:    false
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(1 + TOPIC_FITTED_SIZE);
+    ASSERT_FALSE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
+
+    // stream_id:   valid
+    // data_length: fitted
+    // extected:    true
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(TOPIC_FITTED_SIZE);
+    ASSERT_TRUE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
+}
+
+TEST_F(WriteReadAccessTest, BufferRequest)
+{
+    uint8_t buffer[MTU];
+    uxrStreamId stream_id;
+    uint16_t data_length;
+
+    // stream_id:   no valid
+    // data_length: fitted
+    // extected:    false
+    stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(REQUEST_FITTED_SIZE);
+    ASSERT_FALSE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
+
+    // stream_id:   valid
+    // data_length: no fitted
+    // extected:    false
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(1 + REQUEST_FITTED_SIZE);
+    ASSERT_FALSE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
+
+    // stream_id:   valid
+    // data_length: fitted
+    // extected:    true
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(REQUEST_FITTED_SIZE);
+    ASSERT_TRUE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
+
+}
+
+TEST_F(WriteReadAccessTest, BufferReply)
+{
+    uint8_t buffer[MTU];
+    SampleIdentity sample_id{};
+    uxrStreamId stream_id;
+    uint16_t data_length;
+
+    // stream_id:   no valid
+    // data_length: fitted
+    // extected:    false
+    stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(REPLY_FITTED_SIZE);
+    ASSERT_FALSE(uxr_buffer_reply(&session_, stream_id, requester_id_, &sample_id, buffer, data_length));
+
+    // stream_id:   valid
+    // data_length: no fitted
+    // extected:    false
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(1 + REPLY_FITTED_SIZE);
+    ASSERT_FALSE(uxr_buffer_reply(&session_, stream_id, requester_id_, &sample_id, buffer, data_length));
+
+
+    // stream_id:   valid
+    // data_length: fitted
+    // extected:    true
+    stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
+    data_length = uint16_t(REPLY_FITTED_SIZE);
+    ASSERT_TRUE(uxr_buffer_reply(&session_, stream_id, replier_id_, &sample_id, buffer, data_length));
+
+}

--- a/test/unitary/session/WriteReadAccess.cpp
+++ b/test/unitary/session/WriteReadAccess.cpp
@@ -105,21 +105,21 @@ TEST_F(WriteReadAccessTest, PrepareStreamToWriteSubmessage)
 
     // stream_id:   no valid
     // data_length: fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(TOPIC_FITTED_SIZE);
     ASSERT_FALSE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
 
     // stream_id:   valid
     // data_length: no fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(1 + TOPIC_FITTED_SIZE);
     ASSERT_FALSE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
 
     // stream_id:   valid
     // data_length: fitted
-    // extected:    true
+    // expected:    true
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(TOPIC_FITTED_SIZE);
     ASSERT_TRUE(uxr_prepare_output_stream(&session_, stream_id, data_writer_id_, &ub, data_length));
@@ -133,21 +133,21 @@ TEST_F(WriteReadAccessTest, BufferRequest)
 
     // stream_id:   no valid
     // data_length: fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(REQUEST_FITTED_SIZE);
     ASSERT_FALSE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
 
     // stream_id:   valid
     // data_length: no fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(1 + REQUEST_FITTED_SIZE);
     ASSERT_FALSE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
 
     // stream_id:   valid
     // data_length: fitted
-    // extected:    true
+    // expected:    true
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(REQUEST_FITTED_SIZE);
     ASSERT_TRUE(uxr_buffer_request(&session_, stream_id, requester_id_, buffer, data_length));
@@ -163,14 +163,14 @@ TEST_F(WriteReadAccessTest, BufferReply)
 
     // stream_id:   no valid
     // data_length: fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(1, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(REPLY_FITTED_SIZE);
     ASSERT_FALSE(uxr_buffer_reply(&session_, stream_id, requester_id_, &sample_id, buffer, data_length));
 
     // stream_id:   valid
     // data_length: no fitted
-    // extected:    false
+    // expected:    false
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(1 + REPLY_FITTED_SIZE);
     ASSERT_FALSE(uxr_buffer_reply(&session_, stream_id, requester_id_, &sample_id, buffer, data_length));
@@ -178,7 +178,7 @@ TEST_F(WriteReadAccessTest, BufferReply)
 
     // stream_id:   valid
     // data_length: fitted
-    // extected:    true
+    // expected:    true
     stream_id = uxr_stream_id(0, UXR_BEST_EFFORT_STREAM, UXR_OUTPUT_STREAM);
     data_length = uint16_t(REPLY_FITTED_SIZE);
     ASSERT_TRUE(uxr_buffer_reply(&session_, stream_id, replier_id_, &sample_id, buffer, data_length));


### PR DESCRIPTION
This PR fixes a hotfix at `uxr_read_format` function and add regression tests.
The first CI shall fail because it just contains the regression tests.
Then the fix will be applied and the CI should pass.