### PR TITLE
Fix no poll timeout

### DIFF
--- a/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
@@ -95,6 +95,8 @@ size_t uxr_read_udp_data_platform(
 {
     size_t rv = 0;
 
+    timeout = (timeout <= 0) ? 1 : timeout;
+
     struct timeval tv;
     tv.tv_sec = timeout / 1000;
 	tv.tv_usec = (timeout % 1000) * 1000;


### PR DESCRIPTION
This PR fix the behaviour when `uxr_read_udp_data_platform` get a timeout == 0 and after setting `SO_RCVTIMEO`, `recv()` keeps waiting forever.