### PR TITLE
Implement run session wait until DDS data

### DIFF
--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -102,6 +102,8 @@ typedef struct uxrSession
     uxrOnReplyFunc on_reply;
     void* on_reply_args;
 
+    bool on_data_flag;
+
 #ifdef PERFORMANCE_TESTING
     uxrOnPerformanceFunc on_performance;
     void* on_performance_args;
@@ -300,6 +302,21 @@ UXRDLLAPI bool uxr_run_session_time(
  * @return  `true` in case of the Agent confirms the reception of all the output messages. `false` in other case.
  */
 UXRDLLAPI bool uxr_run_session_timeout(
+        uxrSession* session,
+        int timeout);
+
+/**
+ * @brief  Keeps communication between the Client and the Agent.
+ *         This function involves the following actions:
+ *          1. flashing all the output streams sending the data through the transport,
+ *          2. listening messages from the Agent calling the associated callback (topic, status, request and replies).
+ *        The aforementioned actions will be performed in a loop until a data message is received 
+ *        or the `timeout` is exceeded.
+ * @param session   A uxrSession structure previously initialized.
+ * @param timeout   The waiting time in milliseconds.
+ * @return  `true` in case of a data message is received before the timeout. `false` in other case.
+ */
+UXRDLLAPI bool uxr_run_session_until_data(
         uxrSession* session,
         int timeout);
 

--- a/src/c/core/session/read_access.c
+++ b/src/c/core/session/read_access.c
@@ -169,6 +169,7 @@ inline void read_format_data(
             if (NULL != session->on_topic)
             {
                 session->on_topic(session, object_id, request_id, stream_id, &temp_buffer, length, session->on_topic_args);
+                session->on_data_flag = true;
             }
             break;
         }
@@ -193,6 +194,8 @@ inline void read_format_data(
                         &temp_buffer,
                         (size_t)request_length,
                         session->on_request_args);
+                    
+                    session->on_data_flag = true;
                 }
             }
             break;
@@ -218,6 +221,8 @@ inline void read_format_data(
                         &temp_buffer,
                         (size_t)reply_length,
                         session->on_reply_args);
+                    
+                    session->on_data_flag = true;
                 }
             }
             ub->iterator += length;

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -200,6 +200,25 @@ bool uxr_run_session_timeout(uxrSession* session, int timeout_ms)
     return uxr_output_streams_confirmed(&session->streams);
 }
 
+bool uxr_run_session_until_data(uxrSession* session, int timeout_ms)
+{
+    int64_t start_timestamp = uxr_millis();
+    int remaining_time = timeout_ms;
+
+    uxr_flash_output_streams(session);
+
+    session->on_data_flag = false;
+    while(remaining_time > 0)
+    {
+        listen_message_reliably(session, remaining_time);
+        if (session->on_data_flag){
+            break;
+        }
+        remaining_time = timeout_ms - (int)(uxr_millis() - start_timestamp);
+    }
+    return session->on_data_flag;
+}
+
 bool uxr_run_session_until_timeout(uxrSession* session, int timeout_ms)
 {
     uxr_flash_output_streams(session);


### PR DESCRIPTION
This PR adds a new run session functions that wait until some DDS message has been received: Subscription, Request, or Replies.