### PR TITLE
Add init session function with retries

### DIFF
--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -203,6 +203,15 @@ UXRDLLAPI void uxr_set_performance_callback(uxrSession* session, uxrOnPerformanc
 UXRDLLAPI bool uxr_create_session(uxrSession* session);
 
 /**
+ * @brief Creates a new session with the Agent.
+ *        This function logs in a session, enabling any other XRCE communication with the Agent.
+ * @param session   A uxrSesssion structure previously initialized.
+ * @param retries   Max attempts for creating the session
+ * @return  true in case of successful session establishment, and false in other case.
+ */
+UXRDLLAPI bool uxr_create_session_retries(uxrSession* session, int retries);
+
+/**
  * @brief Deletes a session previously created.
  *        All XRCE entities created within the session will be removed.
  *        This function logs out a session, disabling any other XRCE communication with the Agent.

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -121,7 +121,7 @@ void uxr_set_performance_callback(uxrSession* session, uxrOnPerformanceFunc on_e
 }
 #endif
 
-bool uxr_create_session(uxrSession* session)
+bool uxr_create_session_retries(uxrSession* session, int retries)
 {
     uxr_reset_stream_storage(&session->streams);
 
@@ -132,9 +132,14 @@ bool uxr_create_session(uxrSession* session)
     uxr_buffer_create_session(&session->info, &ub, (uint16_t)(session->comm->mtu - INTERNAL_RELIABLE_BUFFER_OFFSET));
     uxr_stamp_create_session_header(&session->info, ub.init);
 
-    bool received = wait_session_status(session, create_session_buffer, ucdr_buffer_length(&ub), UXR_CONFIG_MAX_SESSION_CONNECTION_ATTEMPTS);
+    bool received = wait_session_status(session, create_session_buffer, ucdr_buffer_length(&ub), (size_t) retries);
     bool created = received && UXR_STATUS_OK == session->info.last_requested_status;
     return created;
+}
+
+bool uxr_create_session(uxrSession* session)
+{
+    return uxr_create_session_retries(session, UXR_CONFIG_MAX_SESSION_CONNECTION_ATTEMPTS);
 }
 
 bool uxr_delete_session(uxrSession* session)


### PR DESCRIPTION
This PR extends the API in order to provide a runtime configurable retry option when creating an XRCE session.