### PR TITLE
Change default discovery port

### DIFF
--- a/include/uxr/client/profile/discovery/discovery.h
+++ b/include/uxr/client/profile/discovery/discovery.h
@@ -31,7 +31,7 @@ extern "C"
 typedef bool (*uxrOnAgentFound) (const TransportLocator* locator, void* args);
 
 /**
- * @brief Discovers Agents within the network using UDP/IP multicast with address "239.255.0.2" and port 7400.
+ * @brief Discovers Agents within the network using UDP/IP multicast with address "239.255.0.2" and port 7401.
  * @param attempts      The times a discovery message is sent across the network.
  * @param period        The period using to send multicast messages through the network.
  * @param on_agent_func The callback function that will be called when an Agent is discovered.

--- a/src/c/profile/discovery/discovery.c
+++ b/src/c/profile/discovery/discovery.c
@@ -16,7 +16,7 @@
 #define GET_INFO_REQUEST_ID 9
 
 #define MULTICAST_DEFAULT_IP   "239.255.0.2"
-#define MULTICAST_DEFAULT_PORT 7400
+#define MULTICAST_DEFAULT_PORT 7401
 
 typedef struct CallbackData
 {


### PR DESCRIPTION
This PR changes the default discovery port defined in DDS-XRCE standard (https://www.omg.org/spec/DDS-XRCE/1.0/PDF page 94) because it interferes with traffic generated in Fast-DDS in the same port.

Before merge, it is necessary to determine why and how Fast-DDS generates traffic in this port.

Related:

https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/193