### PR TITLE
Fix fragmentation first fragment size

### DIFF
--- a/src/c/core/session/stream/output_reliable_stream.c
+++ b/src/c/core/session/stream/output_reliable_stream.c
@@ -117,6 +117,7 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
         if(available_to_write)
         {
             ucdrBuffer temp_ub;
+            uint16_t fragment_size = first_fragment_size;
             for(uint16_t i = 0; i < necessary_blocks - 1; i++)
             {
                 ucdr_init_buffer_origin_offset(
@@ -125,9 +126,10 @@ bool uxr_prepare_reliable_buffer_to_write(uxrOutputReliableStream* stream, size_
                     buffer_capacity,
                     0u,
                     uxr_get_reliable_buffer_size(&stream->base, seq_num));
-                uxr_buffer_submessage_header(&temp_ub, SUBMESSAGE_ID_FRAGMENT, available_block_size, 0);
+                uxr_buffer_submessage_header(&temp_ub, SUBMESSAGE_ID_FRAGMENT, fragment_size, 0);
                 uxr_set_reliable_buffer_size(&stream->base, seq_num, buffer_capacity);
                 seq_num = uxr_seq_num_add(seq_num, 1);
+                fragment_size = available_block_size;
             }
 
             ucdr_init_buffer_origin_offset(

--- a/test/unitary/session/streams/OutputReliableStream.cpp
+++ b/test/unitary/session/streams/OutputReliableStream.cpp
@@ -215,7 +215,7 @@ TEST_F(OutputReliableStreamTest, WriteMultipleFragmentsAndCheckSubHeaders)
     uint8_t client_key[4] = {0xAA, 0xAA, 0xAA, 0xAA};
 
     // Init all message headers
-    for (size_t i = 0; i < HISTORY; i++)
+    for (uint16_t i = 0; i < HISTORY; i++)
     {
         uint8_t* slot = uxr_get_reliable_buffer(&stream.base, i);
         ucdr_init_buffer(&ub, slot, MAX_MESSAGE_SIZE);

--- a/test/unitary/session/streams/OutputReliableStream.cpp
+++ b/test/unitary/session/streams/OutputReliableStream.cpp
@@ -7,6 +7,7 @@ extern "C"
 #include <c/core/session/stream/output_reliable_stream.c>
 #include <c/core/serialization/xrce_subheader.c>
 #include <c/core/session/submessage.c>
+#include <c/core/serialization/xrce_header.c>
 }
 
 #define BUFFER_SIZE           size_t(128)
@@ -205,6 +206,49 @@ TEST_F(OutputReliableStreamTest, WriteTwoFragmentMessage)
     ASSERT_TRUE(available_to_write);
     available_to_write = uxr_prepare_reliable_buffer_to_write(&stream, MAX_FRAGMENT_SIZE*2, &ub);
     ASSERT_TRUE(available_to_write);
+}
+
+
+TEST_F(OutputReliableStreamTest, WriteMultipleFragmentsAndCheckSubHeaders)
+{
+    ucdrBuffer ub;
+    uint8_t client_key[4] = {0xAA, 0xAA, 0xAA, 0xAA};
+
+    uint8_t* slot_0 = uxr_get_reliable_buffer(&stream.base, 0);
+    ucdr_init_buffer(&ub, slot_0, MAX_MESSAGE_SIZE);
+    uxr_serialize_message_header(&ub, SESSION_ID_WITHOUT_CLIENT_KEY-2, 0, 0, client_key);
+
+    uint8_t* slot_1 = uxr_get_reliable_buffer(&stream.base, 1);
+    ucdr_init_buffer(&ub, slot_1, MAX_MESSAGE_SIZE);
+    uxr_serialize_message_header(&ub, SESSION_ID_WITHOUT_CLIENT_KEY-2, 0, 0, client_key);
+
+    size_t first_message_size = 24; //  1.5 * MAX_FRAGMENT_SIZE;
+    bool available_to_write = uxr_prepare_reliable_buffer_to_write(&stream, first_message_size, &ub);
+    ASSERT_TRUE(available_to_write);
+    available_to_write = uxr_prepare_reliable_buffer_to_write(&stream, first_message_size, &ub);
+    ASSERT_TRUE(available_to_write);
+
+    size_t buffer_capacity = uxr_get_reliable_buffer_capacity(&stream.base);
+    for (uint16_t i = 0; i < stream.last_written; i++)
+    {
+        uint8_t * slot = uxr_get_reliable_buffer(&stream.base, i);
+        ucdr_init_buffer_origin_offset(&ub, slot, buffer_capacity, 0u, 0u);
+
+        uint8_t session_id, stream_id; 
+        uint16_t seq_no ;
+        uint8_t output_client_key[4];
+        uxr_deserialize_message_header(&ub, &session_id, &stream_id, &seq_no, output_client_key);
+
+        while (ub.iterator < ub.final)
+        {
+            uint8_t id, flags;
+            uint16_t length;
+            uxr_deserialize_submessage_header(&ub, &id, &flags, &length);
+            uint8_t * fragment = reinterpret_cast<uint8_t*>(malloc(length*sizeof(uint8_t)));
+            ASSERT_TRUE(ucdr_deserialize_array_uint8_t(&ub, fragment, length));
+            free(fragment);
+        }
+    }
 }
 
 TEST_F(OutputReliableStreamTest, WriteMaxSubmessageSize)


### PR DESCRIPTION
This PR adds a regression tests and fixes a bug that does not take into account the submessage fragment size in cases when the first fragment of a fragmented is not written in an empty buffer.

This fix should make https://github.com/micro-ROS/rmw-microxrcedds/pull/84 not necessary