### PR TITLE
Fix discovery deserialization

### DIFF
--- a/src/c/core/serialization/xrce_types.c
+++ b/src/c/core/serialization/xrce_types.c
@@ -271,18 +271,22 @@ bool uxr_serialize_TransportLocatorSeq(ucdrBuffer* buffer, const TransportLocato
 bool uxr_deserialize_TransportLocatorSeq(ucdrBuffer* buffer, TransportLocatorSeq* output)
 {
     bool ret = ucdr_deserialize_uint32_t(buffer, &output->size);
-    if(output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)
+
+    // If locator seq does not fit, only uses the first ones.
+    // This is the case in Agent discovery, take care if this funtion
+    // is used elsewhere.
+
+    output->size = (output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)   ?
+                        UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX               :
+                        output->size;
+
+    for(uint32_t i = 0; i < output->size && ret; i++)
     {
-        buffer->error = true;
-        ret = false;
+        ret = uxr_deserialize_TransportLocator(buffer, &output->data[i]);
     }
-    else
-    {
-        for(uint32_t i = 0; i < output->size && ret; i++)
-        {
-            ret = uxr_deserialize_TransportLocator(buffer, &output->data[i]);
-        }
-    }
+
+    buffer->error =  (output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX) ? true : false;
+
     return ret;
 }
 

--- a/src/c/core/serialization/xrce_types.c
+++ b/src/c/core/serialization/xrce_types.c
@@ -271,22 +271,18 @@ bool uxr_serialize_TransportLocatorSeq(ucdrBuffer* buffer, const TransportLocato
 bool uxr_deserialize_TransportLocatorSeq(ucdrBuffer* buffer, TransportLocatorSeq* output)
 {
     bool ret = ucdr_deserialize_uint32_t(buffer, &output->size);
-
-    // If locator seq does not fit, only uses the first ones.
-    // This is the case in Agent discovery, take care if this funtion
-    // is used elsewhere.
-
-    output->size = (output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)   ?
-                        UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX               :
-                        output->size;
-
-    for(uint32_t i = 0; i < output->size && ret; i++)
+    if(output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)
     {
-        ret = uxr_deserialize_TransportLocator(buffer, &output->data[i]);
+        buffer->error = true;
+        ret = false;
     }
-
-    buffer->error =  (output->size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX) ? true : false;
-
+    else
+    {
+        for(uint32_t i = 0; i < output->size && ret; i++)
+        {
+            ret = uxr_deserialize_TransportLocator(buffer, &output->data[i]);
+        }
+    }
     return ret;
 }
 

--- a/src/c/profile/discovery/discovery.c
+++ b/src/c/profile/discovery/discovery.c
@@ -160,7 +160,7 @@ bool uxr_deserialize_discovery_INFO_Payload(ucdrBuffer* buffer, INFO_Payload* ou
             // if the sent sequence is too long for the allocated UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX
             output->object_info.activity._.agent.address_seq.size = 
                 (output->object_info.activity._.agent.address_seq.size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)   ?
-                    UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX               :
+                    UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX                                                         :
                     output->object_info.activity._.agent.address_seq.size;
 
             for(uint32_t i = 0; i < output->object_info.activity._.agent.address_seq.size && ret; i++)

--- a/src/c/profile/discovery/discovery.c
+++ b/src/c/profile/discovery/discovery.c
@@ -136,6 +136,42 @@ bool read_info_headers(ucdrBuffer* ub)
     return uxr_read_submessage_header(ub, &id, &length, &flags);
 }
 
+bool uxr_deserialize_discovery_INFO_Payload(ucdrBuffer* buffer, INFO_Payload* output)
+{
+    bool ret = true;
+    ret &= uxr_deserialize_BaseObjectReply(buffer, &output->base);
+    ret &= ucdr_deserialize_bool(buffer, &output->object_info.optional_config);
+    if(output->object_info.optional_config == true)
+    {
+        ret &= uxr_deserialize_ObjectVariant(buffer, &output->object_info.config);
+    }
+
+    ret &= ucdr_deserialize_bool(buffer, &output->object_info.optional_activity);
+    if(output->object_info.optional_activity == true)
+    {
+        ret &= ucdr_deserialize_uint8_t(buffer, &output->object_info.activity.kind);
+        ret &= output->object_info.activity.kind == DDS_XRCE_OBJK_AGENT;
+        if (ret)
+        {
+            ret &= ucdr_deserialize_int16_t(buffer, &output->object_info.activity._.agent.availibility);
+            ret &= ucdr_deserialize_uint32_t(buffer, &output->object_info.activity._.agent.address_seq.size);
+            
+            // This function takes care of deserializing at least the possible address_seq items
+            // if the sent sequence is too long for the allocated UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX
+            output->object_info.activity._.agent.address_seq.size = 
+                (output->object_info.activity._.agent.address_seq.size > UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX)   ?
+                    UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX               :
+                    output->object_info.activity._.agent.address_seq.size;
+
+            for(uint32_t i = 0; i < output->object_info.activity._.agent.address_seq.size && ret; i++)
+            {
+                ret &= uxr_deserialize_TransportLocator(buffer, &output->object_info.activity._.agent.address_seq.data[i]);
+            }
+        }
+    }
+    return ret;
+}
+
 bool read_info_message(
         ucdrBuffer* ub,
         CallbackData* callback)
@@ -143,7 +179,7 @@ bool read_info_message(
     bool is_succeed = false;
     INFO_Payload payload;
 
-    if(uxr_deserialize_INFO_Payload(ub, &payload))
+    if(uxr_deserialize_discovery_INFO_Payload(ub, &payload))
     {
         XrceVersion* version = &payload.object_info.config._.agent.xrce_version;
         TransportLocatorSeq * locators = &payload.object_info.activity._.agent.address_seq;


### PR DESCRIPTION
This PR update the deserialization function for Transports locators. This function is used when Agent send the response to the discovery messages.

By default UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX  is set to 4 and if the Agent has more interfaces than this, the client won't deserialize none of them. 

I propose that, if this does not interfere with any other feature, we can deserialize at least UXR_TRANSPORT_LOCATOR_SEQUENCE_MAX when the agent send more than this.

Also we can write a deserialization function specificallty for this case where this is taken into accoun.

Thoughs?