### PR TITLE
Bump micro-CDR to v1.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ set(UCLIENT_CUSTOM_TRANSPORT_MTU 512 CACHE STRING "Set the Custom transport MTU.
 ###############################################################################
 # Dependencies
 ###############################################################################
-set(_microcdr_version 1.2.0)
-set(_microcdr_tag develop)
+set(_microcdr_version 1.2.1)
+set(_microcdr_tag v1.2.1)
 
 set(_deps "")
 list(APPEND _deps "microcdr\;${_microcdr_version}")


### PR DESCRIPTION
Merge when https://github.com/eProsima/Micro-CDR/pull/58 closed and release tagged