### PR TITLE
Fix shared memory lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,10 +221,6 @@ if(UCLIENT_PROFILE_CUSTOM_TRANSPORT)
     list(APPEND _transport_src src/c/profile/transport/custom/custom_transport.c)
 endif()
 
-if(UCLIENT_PROFILE_MULTITHREAD)
-    set(UCLIENT_PROFILE_SHARED_MEMORY ON)
-endif()
-
 if(UCLIENT_PROFILE_SHARED_MEMORY)
     set(UCLIENT_PROFILE_MATCHING ON)
 endif()

--- a/src/c/profile/shared_memory/shared_memory.c
+++ b/src/c/profile/shared_memory/shared_memory.c
@@ -175,6 +175,7 @@ void uxr_prepare_shared_memory(
     ssize_t entity_index = uxr_shared_memory_get_entity_index(session, &entity_id);
     if (-1 == entity_index)
     {
+        UXR_UNLOCK(&uxr_sm_map.lock);
         return;
     }
 


### PR DESCRIPTION
This PR fix a situation where the shared memory engine does not handle correctly the internal mutex.

Also it disables the shared memory engine when multi threading is enabled because those two modes can be used independently.