### PR TITLE
Only add -wdouble-promotion if supported

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -130,12 +130,12 @@ function(set_common_compile_options target)
             -Wsign-conversion
             $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
             $<$<AND:$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:-Wuseless-cast>
-            -Wdouble-promotion
             $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,6.0.0>>>>:-Wnull-dereference>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,7.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,7.0.0>>>>:-Wduplicated-branches>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,6.0.0>>>>:-Wduplicated-cond>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,7.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,7.0.0>>>>:-Wrestrict>
+            $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,4.6.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,4.6.0>>>>:-Wdouble-promotion>
             )
     endif()
 endfunction()


### PR DESCRIPTION
As per subject.

This is basically a duplicate of https://github.com/eProsima/Micro-CDR/pull/65.

GCC `4.6.0` is already really old, but the compiler I'm targetting is even older.

The unconditional addition of `-wdouble-promotion` causes builds to fail so I patch this out locally.

It would be great if this could be merged here, so I have one less patch to apply.

No functional changes to anything and modern compilers will still see `-Wdouble-promotion` added to the flags.

---

Edit: link to the [GCC 4.6.0 docs: Options to Request or Suppress Warnings](https://gcc.gnu.org/onlinedocs/gcc-4.6.0/gcc/Warning-Options.html), and the same page, [but for GCC 4.5.4](https://gcc.gnu.org/onlinedocs/gcc-4.5.4/gcc/Warning-Options.html). The former has the option, the latter doesn't.
