### PR TITLE
session: don't shadow global time(..)

### DIFF
--- a/include/uxr/client/core/session/session.h
+++ b/include/uxr/client/core/session/session.h
@@ -403,14 +403,14 @@ UXRDLLAPI void uxr_flash_output_streams(
  *          1. flashing all the output streams sending the data through the transport,
  *          2. listening messages from the Agent calling the associated callback (topic and status).
  *        The aforementioned actions will be performed in a loop until the waiting time for a new message
- *        exceeds the `time`.
+ *        exceeds the `timeout`.
  * @param session   A uxrSession structure previously initialized.
- * @param time      The waiting time in milliseconds.
+ * @param timeout   The waiting time in milliseconds.
  * @return  `true` in case of the Agent confirms the reception of all the output messages. `false` in other case.
  */
 UXRDLLAPI bool uxr_run_session_time(
         uxrSession* session,
-        int time);
+        int timeout);
 
 /**
  * @brief  Keeps communication between the Client and the Agent.

--- a/src/c/core/session/session.c
+++ b/src/c/core/session/session.c
@@ -491,7 +491,7 @@ bool uxr_run_session_until_one_status(
 
 bool uxr_sync_session(
         uxrSession* session,
-        int time)
+        int timeout)
 {
     UXR_LOCK_SESSION(session);
 
@@ -509,7 +509,7 @@ bool uxr_sync_session(
 
     uxr_stamp_session_header(&session->info, 0, 0, ub.init);
     send_message(session, timestamp_buffer, ucdr_buffer_length(&ub));
-    bool ret = run_session_until_sync(session, time);
+    bool ret = run_session_until_sync(session, timeout);
     UXR_UNLOCK_SESSION(session);
 
     return ret;


### PR DESCRIPTION
As per subject.

This avoids a compiler warning complaining about `time` shadowing `time(..)` from `time.h`.

See discussion in #253.
