### PR TITLE
examples: explicitly set language to C

### DIFF
--- a/examples/BinaryEntityCreation/CMakeLists.txt
+++ b/examples/BinaryEntityCreation/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(BinaryEntityCreation)
+project(BinaryEntityCreation C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/ContinuousFragment/CMakeLists.txt
+++ b/examples/ContinuousFragment/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(ContinuousFragment)
+project(ContinuousFragment C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/CustomTransports/CMakeLists.txt
+++ b/examples/CustomTransports/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(CustomTransports)
+project(CustomTransports C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/Deployment/CMakeLists.txt
+++ b/examples/Deployment/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
     #############################################################
     ###                     CONFIGURATOR
     #############################################################
-    project(ConfiguratorClient)
+    project(ConfiguratorClient C)
 
     if(NOT UCLIENT_BUILD_EXAMPLES)
         find_package(microxrcedds_client REQUIRED)
@@ -50,7 +50,7 @@ else()
     #############################################################
     ###                      PUBLISHER
     #############################################################
-    project(PublisherClient)
+    project(PublisherClient C)
     add_executable(PublisherClient publisher.c HelloWorld.c)
     if(MSVC OR MSVC_IDE)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)
@@ -70,7 +70,7 @@ else()
     #############################################################
     ###                      SUBSCRIBER
     #############################################################
-    project(SubscriberClient)
+    project(SubscriberClient C)
     add_executable(SubscriberClient subscriber.c HelloWorld.c)
     if(MSVC OR MSVC_IDE)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)

--- a/examples/Discovery/CMakeLists.txt
+++ b/examples/Discovery/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
     #############################################################
     ###                       DISCOVERY
     #############################################################
-    project(Discovery)
+    project(Discovery C)
 
     if(NOT UCLIENT_BUILD_EXAMPLES)
         find_package(microxrcedds_client REQUIRED)

--- a/examples/MultiSessionHelloWorld/CMakeLists.txt
+++ b/examples/MultiSessionHelloWorld/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(MultiSessionHelloWorld)
+project(MultiSessionHelloWorld C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PingAgent/Serial/CMakeLists.txt
+++ b/examples/PingAgent/Serial/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PingAgentSerial)
+project(PingAgentSerial C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PingAgent/TCP/CMakeLists.txt
+++ b/examples/PingAgent/TCP/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PingAgentTCP)
+project(PingAgentTCP C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PingAgent/UDP/CMakeLists.txt
+++ b/examples/PingAgent/UDP/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PingAgentUDP)
+project(PingAgentUDP C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PublishHelloWorld/CMakeLists.txt
+++ b/examples/PublishHelloWorld/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PublishHelloWorldClient)
+project(PublishHelloWorldClient C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PublishHelloWorldBestEffort/CMakeLists.txt
+++ b/examples/PublishHelloWorldBestEffort/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PublishHelloWorldClientBestEffort)
+project(PublishHelloWorldClientBestEffort C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/PublishHelloWorldP2P/CMakeLists.txt
+++ b/examples/PublishHelloWorldP2P/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(PublishHelloWorldClientP2P)
+project(PublishHelloWorldClientP2P C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/ReplyAdder/CMakeLists.txt
+++ b/examples/ReplyAdder/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 
-project(ReplyAdder)
+project(ReplyAdder C)
 
 if(NOT UCLIENT_PROFILE_UDP)
     message(WARNING "Can not compile example: the UCLIENT_PROFILE_UDP must be enables.")

--- a/examples/RequestAdder/CMakeLists.txt
+++ b/examples/RequestAdder/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 
-project(RequestAdder)
+project(RequestAdder C)
 
 if(NOT UCLIENT_PROFILE_UDP)
     message(WARNING "Can not compile example: the UCLIENT_PROFILE_UDP must be enables.")

--- a/examples/ShapesDemo/CMakeLists.txt
+++ b/examples/ShapesDemo/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(ShapeDemoClient)
+project(ShapeDemoClient C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/SubscribeHelloWorld/CMakeLists.txt
+++ b/examples/SubscribeHelloWorld/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(SubscribeHelloWorldClient)
+project(SubscribeHelloWorldClient C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/SubscribeHelloWorldBestEffort/CMakeLists.txt
+++ b/examples/SubscribeHelloWorldBestEffort/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(SubscribeHelloWorldClientBestEffort)
+project(SubscribeHelloWorldClientBestEffort C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/SubscribeHelloWorldP2P/CMakeLists.txt
+++ b/examples/SubscribeHelloWorldP2P/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(SubscribeHelloWorldClientP2P)
+project(SubscribeHelloWorldClientP2P C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/TimeSync/CMakeLists.txt
+++ b/examples/TimeSync/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(TimeSync)
+project(TimeSync C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)

--- a/examples/TimeSyncWithCb/CMakeLists.txt
+++ b/examples/TimeSyncWithCb/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${CMAKE_VERSION} VERSION_GREATER 3.0)
     cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(TimeSyncWithCb)
+project(TimeSyncWithCb C)
 
 if(NOT UCLIENT_BUILD_EXAMPLES)
     find_package(microxrcedds_client REQUIRED)


### PR DESCRIPTION
As per subject.

This is a follow-up to #256.

If no language is specified in `project(..)` calls, CMake will (try to) enable C *and* C++ by default.

~~As `Micro-XRCE-DDS-Client` is purely C, there is no need for that.~~ 

As *the examples* are plain C, there should be no need for that (the `test` directory contains some tests which are implemented in C++, so if tests are enabled, the C++ compiler will still be enabled by CMake).
