### PR TITLE
Fixes memory leak due to not deleting freertos socket set

### DIFF
--- a/src/c/profile/discovery/transport/udp_transport_datagram_freertos_plus_tcp.c
+++ b/src/c/profile/discovery/transport/udp_transport_datagram_freertos_plus_tcp.c
@@ -49,6 +49,11 @@ bool uxr_close_udp_transport_datagram(
     /* FreeRTOS_closesocket() always returns 0. */
     (void) FreeRTOS_closesocket(transport->fd);
 
+    if (NULL != transport->poll_fd)
+    {
+        (void) FreeRTOS_DeleteSocketSet(transport->poll_fd);
+    }
+
     return true;
 }
 

--- a/src/c/profile/transport/ip/tcp/tcp_transport_freertos_plus_tcp.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_freertos_plus_tcp.c
@@ -76,6 +76,11 @@ bool uxr_close_tcp_platform(
      * FreeRTOS_closesocket() always returns 0. */
     (void) FreeRTOS_closesocket(platform->fd);
 
+    if (NULL != platform->poll_fd)
+    {
+        (void) FreeRTOS_DeleteSocketSet(platform->poll_fd);
+    }
+
     return true;
 }
 

--- a/src/c/profile/transport/ip/udp/udp_transport_freertos_plus_tcp.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_freertos_plus_tcp.c
@@ -61,6 +61,11 @@ bool uxr_close_udp_platform(
     /* FreeRTOS_closesocket() always returns 0. */
     (void) FreeRTOS_closesocket(platform->fd);
 
+    if (NULL != platform->poll_fd)
+    {
+        (void) FreeRTOS_DeleteSocketSet(platform->poll_fd);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
This is an issue that probably went over the top of the head of everyone as this transport was added before the "ping" util was added.

However, when using the "Ping" it'd create a socket and a socket set to do Select, to later never release the socket set.