### PR TITLE
allow for pinging once and and return

### DIFF
--- a/src/c/util/ping.c
+++ b/src/c/util/ping.c
@@ -47,12 +47,12 @@ bool uxr_ping_agent_attempts(
             int64_t timestamp = uxr_millis();
             int poll = timeout;
 
-            while (0 < poll && !agent_pong)
+            do
             {
                 agent_pong = listen_info_message(comm, timeout);
                 poll -= (int)(uxr_millis() - timestamp);
                 timestamp = uxr_millis();
-            }
+            } while (0 < poll && !agent_pong);
 
             UXR_UNLOCK_TRANSPORT(comm);
         }


### PR DESCRIPTION
Setting ping timeout is 0 will ping once and return. So calling `rmw_uros_ping_agent(0, 1)` will ping at least once and return.