### PR TITLE
Fix fragment capacity overflow

### DIFF
--- a/src/c/core/session/write_access.c
+++ b/src/c/core/session/write_access.c
@@ -177,7 +177,7 @@ bool on_full_output_buffer_fragmented(
         0u,
         uxr_get_reliable_buffer_size(&stream->base, stream->last_written));
 
-    if (local_args->data_size <= buffer_capacity)
+    if ((local_args->data_size + SUBHEADER_SIZE + WRITE_DATA_PAYLOAD_SIZE) <= buffer_capacity)
     {
         uxr_buffer_submessage_header(&temp_ub, SUBMESSAGE_ID_FRAGMENT, (uint16_t) local_args->data_size,
                 FLAG_LAST_FRAGMENT);


### PR DESCRIPTION
Last fragment contains `local_args->data_size + SUBHEADER_SIZE + WRITE_DATA_PAYLOAD_SIZE` data, and previous if condition only checks for `local_args->data_size <= buffer_capacity`:

https://github.com/eProsima/Micro-XRCE-DDS-Client/blob/e1ef8c6531027d3a8282cf1e2f8e9fb61f527043/src/c/core/session/write_access.c#L180-L186