### PR TITLE
RTEMS Serial Transport support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ if(UCLIENT_PROFILE_SERIAL)
     list(APPEND _transport_src src/c/profile/transport/serial/serial_transport.c)
     if(UCLIENT_PLATFORM_POSIX)
         list(APPEND _transport_src src/c/profile/transport/serial/serial_transport_posix.c)
+    elseif(UCLIENT_PLATFORM_RTEMS_BSD_NET)
+        list(APPEND _transport_src src/c/profile/transport/serial/serial_transport_rtems_bsd_net.c)
     endif()
 endif()
 

--- a/include/uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h
+++ b/include/uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h
@@ -1,0 +1,35 @@
+// Copyright 2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTPOSIX_H_
+#define UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTPOSIX_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // ifdef __cplusplus
+
+#include "sys/select.h"
+
+typedef struct uxrSerialPlatform
+{
+    struct fd_set select_fd;
+    int fd;
+} uxrSerialPlatform;
+
+#ifdef __cplusplus
+}
+#endif // ifdef __cplusplus
+
+#endif // UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTPOSIX_H_

--- a/include/uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h
+++ b/include/uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTPOSIX_H_
-#define UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTPOSIX_H_
+#ifndef UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTRTEMS_H_
+#define UXR_CLIENT_PROFILE_TRANSPORT_SERIAL_SERIALTRANSPORTRTEMS_H_
 
 #ifdef __cplusplus
 extern "C"

--- a/include/uxr/client/transport.h
+++ b/include/uxr/client/transport.h
@@ -46,6 +46,8 @@
 #ifdef UCLIENT_PROFILE_SERIAL
 #if defined(UCLIENT_PLATFORM_POSIX)
 #include <uxr/client/profile/transport/serial/serial_transport_posix.h>
+#elif defined(UCLIENT_PLATFORM_RTEMS_BSD_NET)
+#include <uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h>
 #endif // if defined(UCLIENT_EXTERNAL_SERIAL)
 #include <uxr/client/profile/transport/serial/serial_transport.h>
 #endif //UCLIENT_PROFILE_SERIAL

--- a/src/c/profile/transport/serial/serial_transport_rtems_bsd_net.c
+++ b/src/c/profile/transport/serial/serial_transport_rtems_bsd_net.c
@@ -1,0 +1,92 @@
+#include <uxr/client/profile/transport/serial/serial_transport_rtems_bsd_net.h>
+#include <uxr/client/profile/transport/serial/serial_transport_platform.h>
+
+#include <unistd.h>
+#include <errno.h>
+
+bool uxr_init_serial_platform(
+        void* args,
+        int fd,
+        uint8_t remote_addr,
+        uint8_t local_addr)
+{
+    (void) remote_addr;
+    (void) local_addr;
+
+    struct uxrSerialPlatform* platform = (struct uxrSerialPlatform*) args;
+
+    platform->fd = fd;
+
+    /* Poll setup. */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wsign-conversion"
+    FD_ZERO(&platform->select_fd);
+    FD_SET(platform->fd, &platform->select_fd);
+    #pragma GCC diagnostic pop
+    return true;
+}
+
+bool uxr_close_serial_platform(
+        void* args)
+{
+    struct uxrSerialPlatform* platform = (struct uxrSerialPlatform*) args;
+    return (-1 == platform->fd) ? true : (0 == close(platform->fd));
+}
+
+size_t uxr_write_serial_data_platform(
+        void* args,
+        const uint8_t* buf,
+        size_t len,
+        uint8_t* errcode)
+{
+    size_t rv = 0;
+    struct uxrSerialPlatform* platform = (struct uxrSerialPlatform*) args;
+
+    ssize_t bytes_written = write(platform->fd, (void*)buf, (size_t)len);
+    if (-1 != bytes_written)
+    {
+        rv = (size_t)bytes_written;
+        *errcode = 0;
+    }
+    else
+    {
+        *errcode = 1;
+    }
+    return rv;
+}
+
+size_t uxr_read_serial_data_platform(
+        void* args,
+        uint8_t* buf,
+        size_t len,
+        int timeout,
+        uint8_t* errcode)
+{
+    size_t rv = 0;
+    struct uxrSerialPlatform* platform = (struct uxrSerialPlatform*) args;
+
+    struct timeval tv;
+    tv.tv_sec = timeout / 1000;
+    tv.tv_usec = (timeout % 1000) * 1000;
+
+    fd_set fds = platform->select_fd;
+    int32_t poll_rv = select(platform->fd + 1, &fds, NULL, NULL, &tv);
+    if (0 < poll_rv)
+    {
+        ssize_t bytes_read = read(platform->fd, buf, len);
+        if (-1 != bytes_read)
+        {
+            rv = (size_t)bytes_read;
+            *errcode = 0;
+        }
+        else
+        {
+            *errcode = 1;
+        }
+    }
+    else
+    {
+        *errcode = (0 == poll_rv) ? 0 : 1;
+    }
+    return rv;
+}


### PR DESCRIPTION
Following #283 and #287, made a rapid patch for serial transport support. 
Tested with PingPong app as usual.

Details about how to test this transport using QEMU will be added in https://github.com/micro-ROS/micro_ros_setup/issues/397 tracker issue.

Note: as for TCP/UDP, this patch implements a variant of POSIX transports using `select()` call instead of `poll()` call, which is not officially supported by RTEMS 5 core. Even if RTEMS-libBSD adds some `poll()` support, many boards (BSPs) would be potentially excluded from microROS usage due to inability to build libBSD for them.