### PR TITLE
change --gc-section flag to --gc-sections flag

### DIFF
--- a/examples/BinaryEntityCreation/CMakeLists.txt
+++ b/examples/BinaryEntityCreation/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/ContinuousFragment/CMakeLists.txt
+++ b/examples/ContinuousFragment/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/CustomTransports/CMakeLists.txt
+++ b/examples/CustomTransports/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/Deployment/CMakeLists.txt
+++ b/examples/Deployment/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)
     endif()
 
-    target_link_libraries(ConfiguratorClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(ConfiguratorClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(
@@ -56,7 +56,7 @@ else()
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)
     endif()
 
-    target_link_libraries(PublisherClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(PublisherClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(
@@ -76,7 +76,7 @@ else()
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)
     endif()
 
-    target_link_libraries(SubscriberClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(SubscriberClient microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/Discovery/CMakeLists.txt
+++ b/examples/Discovery/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         target_compile_options(${PROJECT_NAME} PRIVATE /wd4996)
     endif()
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/MultiSessionHelloWorld/CMakeLists.txt
+++ b/examples/MultiSessionHelloWorld/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PingAgent/Serial/CMakeLists.txt
+++ b/examples/PingAgent/Serial/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PingAgent/TCP/CMakeLists.txt
+++ b/examples/PingAgent/TCP/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PingAgent/UDP/CMakeLists.txt
+++ b/examples/PingAgent/UDP/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PublishHelloWorld/CMakeLists.txt
+++ b/examples/PublishHelloWorld/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PublishHelloWorldBestEffort/CMakeLists.txt
+++ b/examples/PublishHelloWorldBestEffort/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PublishHelloWorldCAN/CMakeLists.txt
+++ b/examples/PublishHelloWorldCAN/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/PublishHelloWorldP2P/CMakeLists.txt
+++ b/examples/PublishHelloWorldP2P/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/ShapesDemo/CMakeLists.txt
+++ b/examples/ShapesDemo/CMakeLists.txt
@@ -50,7 +50,7 @@ if(BUILD_EXAMPLE)
         PRIVATE
         microxrcedds_client
         $<$<BOOL:${WIN32}>:ws2_32>
-        $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>
+        $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>
         )
 
     if(UCLIENT_INSTALL_EXAMPLES)

--- a/examples/SharedMemoryPubSub/CMakeLists.txt
+++ b/examples/SharedMemoryPubSub/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     C_STANDARD_REQUIRED YES
     )
 
-target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
 if(UCLIENT_INSTALL_EXAMPLES)
     install(

--- a/examples/SharedMemoryReqRep/CMakeLists.txt
+++ b/examples/SharedMemoryReqRep/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     C_STANDARD_REQUIRED YES
     )
 
-target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
 if(UCLIENT_INSTALL_EXAMPLES)
     install(

--- a/examples/SubscribeHelloWorld/CMakeLists.txt
+++ b/examples/SubscribeHelloWorld/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
         )
 
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/SubscribeHelloWorldBestEffort/CMakeLists.txt
+++ b/examples/SubscribeHelloWorldBestEffort/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
         )
 
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/SubscribeHelloWorldP2P/CMakeLists.txt
+++ b/examples/SubscribeHelloWorldP2P/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
         )
 
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/TimeSync/CMakeLists.txt
+++ b/examples/TimeSync/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(

--- a/examples/TimeSyncWithCb/CMakeLists.txt
+++ b/examples/TimeSyncWithCb/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         C_STANDARD_REQUIRED YES
         )
 
-    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-section,--no-export-dynamic>)
+    target_link_libraries(${PROJECT_NAME} microxrcedds_client $<$<C_COMPILER_ID:GNU>:-Wl,--gc-sections,--no-export-dynamic>)
 
     if(UCLIENT_INSTALL_EXAMPLES)
         install(


### PR DESCRIPTION
There's a typo in the example CMakeLists.txt files, see from the GCC manual there's no `--gc-section` option, the correct one should be `--gc-sections`: https://gcc.gnu.org/onlinedocs/gnat_ugn/Compilation-options.html