### PR TITLE
fix udp_transport: call freeaddrinfo only if getaddrinfo succeeded

### DIFF
--- a/src/c/profile/transport/ip/udp/udp_transport_posix.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_posix.c
@@ -54,8 +54,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
@@ -55,8 +55,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/udp/udp_transport_windows.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_windows.c
@@ -56,8 +56,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }


### PR DESCRIPTION
Otherwise freeaddrinfo can access invalid memory.