### PR TITLE
Unlock stream after locking while stream preparing

### DIFF
--- a/src/c/core/session/write_access.c
+++ b/src/c/core/session/write_access.c
@@ -135,10 +135,8 @@ uint16_t uxr_prepare_output_stream(
 
         UXR_PREPARE_SHARED_MEMORY(session, entity_id, ub, (uint16_t) len, rv);
     }
-    else
-    {
-        UXR_UNLOCK_STREAM_ID(session, stream_id);
-    }
+
+    UXR_UNLOCK_STREAM_ID(session, stream_id);
 
     return rv;
 }


### PR DESCRIPTION
Using `uxr_prepare_output_stream()` in two concurrent threads of FreeRTOS before `uxr_run_session_until_confirm_delivery()` blocks one of the threads forever due the `stream_id` not being unlocked after locking. In other words, a recursive mutex is taken and given an unequal number of times.