### PR TITLE
transport/can: Rename UXR_CONFIG_CAN_TRANSPORT_MTU

### DIFF
--- a/examples/PublishHelloWorldCAN/main.c
+++ b/examples/PublishHelloWorldCAN/main.c
@@ -22,7 +22,7 @@
 #include <stdlib.h> //atoi
 
 #define STREAM_HISTORY  8
-#define BUFFER_SIZE     UXR_CONFIG_CAN_TRANSPORT_MTU* STREAM_HISTORY
+#define BUFFER_SIZE     UXR_CAN_TRANSPORT_MTU* STREAM_HISTORY
 
 int main(
         int args,

--- a/include/uxr/client/profile/transport/can/can_transport.h
+++ b/include/uxr/client/profile/transport/can/can_transport.h
@@ -29,11 +29,12 @@ extern "C"
 #include <uxr/client/visibility.h>
 #include <uxr/client/transport.h>
 
-#define UXR_CONFIG_CAN_TRANSPORT_MTU 63
+/* For CAN-FD, MTU is fixed value */
+#define UXR_CAN_TRANSPORT_MTU 63
 
 typedef struct uxrCANTransport
 {
-    uint8_t buffer[UXR_CONFIG_CAN_TRANSPORT_MTU];
+    uint8_t buffer[UXR_CAN_TRANSPORT_MTU];
     uxrCommunication comm;
     struct uxrCANPlatform platform;
 } uxrCANTransport;

--- a/src/c/profile/transport/can/can_transport.c
+++ b/src/c/profile/transport/can/can_transport.c
@@ -103,7 +103,7 @@ bool uxr_init_can_transport(
         transport->comm.send_msg = send_can_msg;
         transport->comm.recv_msg = recv_can_msg;
         transport->comm.comm_error = get_can_error;
-        transport->comm.mtu = UXR_CONFIG_CAN_TRANSPORT_MTU;
+        transport->comm.mtu = UXR_CAN_TRANSPORT_MTU;
         UXR_INIT_LOCK(&transport->comm.mutex);
         rv = true;
     }


### PR DESCRIPTION
Because CAN-FD MTU is fixed, it's not configurable. UXR_CONFIG_CAN_TRANSPORT_MTU is a bit misleading. Thus, this commit rename it to UXR_CAN_TRANSPORT_MTU.

Hope you like it.