### PR TITLE
Fixed removal of z_impl_clock_gettime in zephyr 3.5.99

### DIFF
--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -62,11 +62,10 @@ int64_t uxr_nanos(
     // https://github.com/zephyrproject-rtos/zephyr/commit/95a22b12174621aeba8ca3e0e61f7c66f03202bf
     #if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 5, 99)
     clock_gettime(CLOCK_REALTIME, &ts);
-    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
     #else
     z_impl_clock_gettime(CLOCK_REALTIME, &ts);
-    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
     #endif /* if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 5, 99) */
+    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
 #else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -7,6 +7,8 @@
 #elif defined(UCLIENT_PLATFORM_FREERTOS_PLUS_TCP)
 #include "FreeRTOS.h"
 #include "task.h"
+#elif defined(UCLIENT_PLATFORM_ZEPHYR)
+#include <version.h> 
 #endif /* ifdef WIN32 */
 
 //==================================================================
@@ -53,8 +55,18 @@ int64_t uxr_nanos(
     return (( total_tick / (int64_t) portTICK_PERIOD_MS ) * 1000000 );
 #elif defined(UCLIENT_PLATFORM_ZEPHYR)
     struct timespec ts;
-    z_impl_clock_gettime(CLOCK_REALTIME, &ts);
-    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
+
+    // From Zephyr version 3.5.99 the z_impl_clock_gettime function
+    // has been renamed to the clock_gettime function. 
+    // This has been done to implement Zephyr's POSIX API as regular library functions
+    // https://github.com/zephyrproject-rtos/zephyr/commit/95a22b12174621aeba8ca3e0e61f7c66f03202bf
+    #if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3,5,99)  
+        clock_gettime(CLOCK_REALTIME, &ts);
+        return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
+    #else
+       z_impl_clock_gettime(CLOCK_REALTIME, &ts);
+       return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
+    #endif
 #else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/src/c/util/time.c
+++ b/src/c/util/time.c
@@ -8,7 +8,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #elif defined(UCLIENT_PLATFORM_ZEPHYR)
-#include <version.h> 
+#include <version.h>
 #endif /* ifdef WIN32 */
 
 //==================================================================
@@ -57,16 +57,16 @@ int64_t uxr_nanos(
     struct timespec ts;
 
     // From Zephyr version 3.5.99 the z_impl_clock_gettime function
-    // has been renamed to the clock_gettime function. 
+    // has been renamed to the clock_gettime function.
     // This has been done to implement Zephyr's POSIX API as regular library functions
     // https://github.com/zephyrproject-rtos/zephyr/commit/95a22b12174621aeba8ca3e0e61f7c66f03202bf
-    #if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3,5,99)  
-        clock_gettime(CLOCK_REALTIME, &ts);
-        return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
+    #if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 5, 99)
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
     #else
-       z_impl_clock_gettime(CLOCK_REALTIME, &ts);
-       return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
-    #endif
+    z_impl_clock_gettime(CLOCK_REALTIME, &ts);
+    return (((int64_t)ts.tv_sec) * 1000000000) + ts.tv_nsec;
+    #endif /* if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 5, 99) */
 #else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);


### PR DESCRIPTION
Solution to the following problem: https://github.com/micro-ROS/micro_ros_zephyr_module/issues/134

The notified problem is: " in function uxr_nanos': undefined reference to z_impl_clock_gettime' "
The Zephyr developers have removed the `z_impl_clock_gettime' function and replaced it by the clock_gettime function.
I have implemented the new function in the time.c file, while maintaining compatibility with the older zephyr versions.