### PR TITLE
Fix k_mutex incomplete type on Zephyr

### DIFF
--- a/include/uxr/client/profile/multithread/multithread.h
+++ b/include/uxr/client/profile/multithread/multithread.h
@@ -33,7 +33,12 @@ struct uxrSession;
 #include "FreeRTOS.h"
 #include "semphr.h"
 #elif defined(UCLIENT_PLATFORM_ZEPHYR)
+#include <version.h>
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 1, 0)
 #include <zephyr/kernel.h>
+#else
+#include <zephyr.h>
+#endif
 #elif defined(UCLIENT_PLATFORM_POSIX)
 #include <pthread.h>
 #endif // ifdef WIN32

--- a/include/uxr/client/profile/multithread/multithread.h
+++ b/include/uxr/client/profile/multithread/multithread.h
@@ -33,6 +33,7 @@ struct uxrSession;
 #include "FreeRTOS.h"
 #include "semphr.h"
 #elif defined(UCLIENT_PLATFORM_ZEPHYR)
+#include <zephyr/kernel.h>
 #elif defined(UCLIENT_PLATFORM_POSIX)
 #include <pthread.h>
 #endif // ifdef WIN32


### PR DESCRIPTION
Including <zephyr/kernel.h> on UCLIENT_PLATFORM_ZEPHYR resolves the build failure.