### PR TITLE
Use raw regex string in memory map analysis

### DIFF
--- a/test/memory/memory_map/memory_map_analysis.py
+++ b/test/memory/memory_map/memory_map_analysis.py
@@ -2,7 +2,7 @@ import sys
 import re
 import csv
 
-pattern = re.compile('(?P<name>[\w]+)\s(?P<text>[\d]+)\s(?P<data>[\d]+)\s(?P<bss>[\d]+)\s')
+pattern = re.compile(r'(?P<name>[\w]+)\s(?P<text>[\d]+)\s(?P<data>[\d]+)\s(?P<bss>[\d]+)\s')
 
 # Take data from file.
 complete_profile_data = []


### PR DESCRIPTION
## Summary
- use a raw string literal for the memory map parser regex
- remove the invalid escape sequence `SyntaxWarning` on newer Python versions without changing the regex pattern

## Duplicate check
- No open PR or issue found for `memory_map_analysis`.
- No open PR or issue found for `SyntaxWarning`.

## Validation
- `python -W error::SyntaxWarning -m py_compile test/memory/memory_map/memory_map_analysis.py`
- repository Python warning-as-error compile scan reports `TOTAL 0`
- ran `test/memory/memory_map/memory_map_analysis.py` on a small sample input and verified CSV output is generated
- `git diff --check`
- `git ls-files --eol test/memory/memory_map/memory_map_analysis.py`