### PR TITLE
Fix Zephyr discovery IPv4 conversion

### DIFF
--- a/src/c/profile/discovery/transport/udp_transport_datagram_posix.c
+++ b/src/c/profile/discovery/transport/udp_transport_datagram_posix.c
@@ -84,7 +84,7 @@ void uxr_bytes_to_ip(
         char* ip)
 {
     struct in_addr addr;
-    addr.s_addr = (in_addr_t)(*bytes + (*(bytes + 1) << 8) + (*(bytes + 2) << 16) + (*(bytes + 3) << 24));
+    memcpy(&addr.s_addr, bytes, sizeof(addr.s_addr));
     char* internal_ip = inet_ntoa(addr);
     strcpy(ip, internal_ip);
 }

--- a/src/c/profile/discovery/transport/udp_transport_datagram_posix_nopoll.c
+++ b/src/c/profile/discovery/transport/udp_transport_datagram_posix_nopoll.c
@@ -88,7 +88,7 @@ void uxr_bytes_to_ip(
         char* ip)
 {
     struct in_addr addr;
-    addr.s_addr = (in_addr_t)(*bytes + (*(bytes + 1) << 8) + (*(bytes + 2) << 16) + (*(bytes + 3) << 24));
+    memcpy(&addr.s_addr, bytes, sizeof(addr.s_addr));
     char* internal_ip = inet_ntoa(addr);
     strcpy(ip, internal_ip);
 }

--- a/test/unitary/CMakeLists.txt
+++ b/test/unitary/CMakeLists.txt
@@ -89,4 +89,6 @@ unitary_test(SessionInfo        session/SessionInfo.cpp)
 unitary_test(Session            session/Session.cpp)
 unitary_test(WriteReadAccess    session/WriteReadAccess.cpp)
 unitary_test(Utils              session/Utils.cpp)
+unitary_test(DiscoveryTransport profile/DiscoveryTransport.cpp)
+target_link_libraries(DiscoveryTransport PRIVATE microxrcedds_client)
 

--- a/test/unitary/profile/DiscoveryTransport.cpp
+++ b/test/unitary/profile/DiscoveryTransport.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include <c/profile/discovery/transport/udp_transport_datagram_internal.h>
+}
+
+TEST(DiscoveryTransportTest, ConvertsIpv4AddressBytes)
+{
+    const uint8_t address[] = {192, 168, 1, 42};
+    char ip[16] = {};
+
+    uxr_bytes_to_ip(address, ip);
+
+    EXPECT_STREQ("192.168.1.42", ip);
+}


### PR DESCRIPTION
## Summary
- copy discovery IPv4 bytes directly into `struct in_addr` storage in both POSIX discovery backends
- avoid requiring the optional `in_addr_t` typedef, which Zephyr's minimal libc does not provide
- add a unit test for IPv4 address byte conversion

This addresses the `in_addr_t` build failure reported in #397 without changing the public discovery API.

## Root cause
CMake classifies Zephyr as `UCLIENT_PLATFORM_POSIX`, so its discovery build compiles these POSIX backends. Zephyr 2.7.1 defines `struct in_addr.s_addr` as `uint32_t`, but its minimal libc does not define `in_addr_t`.

## Testing
- MinGW GCC 16.1.0 full library and unit-test build
- `ctest --output-on-failure`: 15/15 tests passed
- Zephyr 2.7.1 header-shape compile check: previous expression fails on missing `in_addr_t`; the new copy compiles and preserves all four address bytes
- `git diff --check`